### PR TITLE
Fixed the JPEG watermark benchmark.

### DIFF
--- a/resize_test.go
+++ b/resize_test.go
@@ -278,7 +278,7 @@ func BenchmarkWatermarkJpeg(b *testing.B) {
 			Background: Color{255, 255, 255},
 		},
 	}
-	runBenchmarkResize("test.webp", options, b)
+	runBenchmarkResize("test.jpg", options, b)
 }
 
 func BenchmarkWatermarPng(b *testing.B) {


### PR DESCRIPTION
I believe the wrong image type was being used for the benchmark.  It didn't match the pattern of the other tests.