### PR TITLE
Problem with building bimg on Debian Jessie

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -64,6 +64,18 @@ vips_shrink_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrin
 int
 vips_rotate(VipsImage *in, VipsImage **out, int angle)
 {
+#if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
+/*
+ * Starting libvips 7.41, VIPS_ANGLE_x has been renamed to VIPS_ANGLE_Dx
+ * "to help python". So we provide the macro to correctly build for versions
+ * before 7.41.x.
+ * https://github.com/jcupitt/libvips/blob/master/ChangeLog#L128
+ */
+# define VIPS_ANGLE_D0 VIPS_ANGLE_0
+# define VIPS_ANGLE_D90 VIPS_ANGLE_90
+# define VIPS_ANGLE_D180 VIPS_ANGLE_180
+# define VIPS_ANGLE_D270 VIPS_ANGLE_270
+#endif
 	int rotate = VIPS_ANGLE_D0;
 
 	if (angle == 90) {

--- a/vips.h
+++ b/vips.h
@@ -31,6 +31,25 @@ typedef struct {
 	double Background[3];
 } WatermarkOptions;
 
+/*
+ * This method is here to handle the weird initialization of the vips lib.
+ * libvips use a macro VIPS_INIT() that call vips__init() in version < 7.41,
+ * or calls vips_init() in version >= 7.41.
+ * Anyway, it's not possible to build bimg on Debian Jessie with libvips 7.40.x,
+ * as vips_init() is a macro to VIPS_INIT(), which is also a macro, hence, cgo
+ * is unable to determine the return type of vips_init(), making the build impossible.
+ * In order to correctly build bimg, for version < 7.41, we should undef vips_init and
+ * creates a vips_init() method that calls VIPS_INIT().
+ */
+#if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
+# undef vips_init
+int
+vips_init(const char *argv0)
+{
+	return VIPS_INIT(argv0);
+}
+#endif
+
 void
 vips_enable_cache_set_trace()
 {


### PR DESCRIPTION
There is several problems with libvips and bimg on Debian Jessie.
First one, as of today, libvips on Jessie is in version 7.40.6 (https://packages.debian.org/jessie/libvips38).

```
% go build
# github.com/zllak/bimg
could not determine kind of name for C.vips_init

gcc errors for preamble:
In file included from ./vips.go:5:0:
vips.h: In function 'vips_rotate':
vips.h:67:15: error: 'VIPS_ANGLE_D0' undeclared (first use in this function)
  int rotate = VIPS_ANGLE_D0;
               ^
vips.h:67:15: note: each undeclared identifier is reported only once for each function it appears in
vips.h:70:12: error: 'VIPS_ANGLE_D90' undeclared (first use in this function)
   rotate = VIPS_ANGLE_D90;
            ^
vips.h:72:12: error: 'VIPS_ANGLE_D180' undeclared (first use in this function)
   rotate = VIPS_ANGLE_D180;
            ^
vips.h:74:12: error: 'VIPS_ANGLE_D270' undeclared (first use in this function)
   rotate = VIPS_ANGLE_D270;
```


In version 7.41, a lot of macros have been renamed, with no compatibility
whatsoever in libvips.
So my first commit is to redefine those missing macros.

Second problem is the vips_init() method.
In version < 7.41, vips_init is a macro to VIPS_INIT(), which perform some
library version checks, and call the vips__init() method.
They decided that the name vips__init() was not correct (which it is ..).
They seem to recommend initializing vips with the macro VIPS_INIT().
Problem is that cgo is unable to determine the return type of this macro.
A solution for version prior to 7.41 is to undef the vips_init() macro and create
a method that has the correct definition.

Another important information, in order to correctly build/link the lib, you have
to make absolutely sure that libjpeg-dev/libjpeg8 is **NOT** installed.
Only libjpeg62-turbo-dev and libjpeg62-turbo must be installed.

Let me know if you have some feedback on that.