### PR TITLE
Gaussian Blur

### DIFF
--- a/options.go
+++ b/options.go
@@ -91,6 +91,11 @@ type Watermark struct {
 	Background  Color
 }
 
+type GaussianBlur struct {
+	Sigma   float64
+	MinAmpl float64
+}
+
 type Options struct {
 	Height         int
 	Width          int
@@ -117,4 +122,5 @@ type Options struct {
 	Type           ImageType
 	Interpolator   Interpolator
 	Interpretation Interpretation
+	GaussianBlur   GaussianBlur
 }

--- a/resize.go
+++ b/resize.go
@@ -135,7 +135,8 @@ func normalizeOperation(o *Options, inWidth, inHeight int) {
 
 func shouldTransformImage(o Options, inWidth, inHeight int) bool {
 	return o.Force || (o.Width > 0 && o.Width != inWidth) ||
-		(o.Height > 0 && o.Height != inHeight) || o.AreaWidth > 0 || o.AreaHeight > 0
+		(o.Height > 0 && o.Height != inHeight) || o.AreaWidth > 0 || o.AreaHeight > 0 ||
+		o.GaussianBlur.Sigma > 0 || o.GaussianBlur.MinAmpl > 0
 }
 
 func transformImage(image *C.VipsImage, o Options, shrink int, residual float64) (*C.VipsImage, error) {
@@ -170,6 +171,13 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 	image, err = extractOrEmbedImage(image, o)
 	if err != nil {
 		return nil, err
+	}
+
+	if o.GaussianBlur.Sigma > 0 || o.GaussianBlur.MinAmpl > 0 {
+		image, err = vipsGaussianBlur(image, o.GaussianBlur)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	debug("Transform: shrink=%v, residual=%v, interpolator=%v",

--- a/vips.go
+++ b/vips.go
@@ -437,7 +437,7 @@ func vipsGaussianBlur(image *C.VipsImage, o GaussianBlur) (*C.VipsImage, error) 
 	var out *C.VipsImage
 	defer C.g_object_unref(C.gpointer(image))
 
-	err := C.vips__gaussblur(image, &out, C.double(o.Sigma), C.double(o.MinAmpl))
+	err := C.vips_gaussblur_bridge(image, &out, C.double(o.Sigma), C.double(o.MinAmpl))
 	if err != 0 {
 		return nil, catchVipsError()
 	}

--- a/vips.go
+++ b/vips.go
@@ -432,3 +432,14 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
+
+func vipsGaussianBlur(image *C.VipsImage, o GaussianBlur) (*C.VipsImage, error) {
+	var out *C.VipsImage
+	defer C.g_object_unref(C.gpointer(image))
+
+	err := C.vips__gaussblur(image, &out, C.double(o.Sigma), C.double(o.MinAmpl))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return out, nil
+}

--- a/vips.h
+++ b/vips.h
@@ -330,6 +330,6 @@ vips__gaussblur(VipsImage *in, VipsImage **out, double sigma, double min_ampl) {
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
 	return vips_gaussblur(in, out, ceil(sigma), NULL);
 #else
-	return vips_gaussblur(in, out, sigma, NULL, "min_ampl", min_ampl);
+	return vips_gaussblur(in, out, sigma, NULL, "min_ampl", min_ampl, NULL);
 #endif
 }

--- a/vips.h
+++ b/vips.h
@@ -16,6 +16,9 @@
  */
 
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
+/* we need math.h for ceil() in vips__gaussblur */
+#include <math.h>
+
 #define VIPS_ANGLE_D0 VIPS_ANGLE_0
 #define VIPS_ANGLE_D90 VIPS_ANGLE_90
 #define VIPS_ANGLE_D180 VIPS_ANGLE_180
@@ -320,4 +323,13 @@ vips_watermark(VipsImage *in, VipsImage **out, WatermarkTextOptions *to, Waterma
 
 	g_object_unref(base);
 	return 0;
+}
+
+int
+vips__gaussblur(VipsImage *in, VipsImage **out, double sigma, double min_ampl) {
+#if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
+	return vips_gaussblur(in, out, ceil(sigma), NULL);
+#else
+	return vips_gaussblur(in, out, sigma, NULL, "min_ampl", min_ampl);
+#endif
 }

--- a/vips.h
+++ b/vips.h
@@ -16,9 +16,6 @@
  */
 
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
-/* we need math.h for ceil() in vips_gaussblur_bridge */
-#include <math.h>
-
 #define VIPS_ANGLE_D0 VIPS_ANGLE_0
 #define VIPS_ANGLE_D90 VIPS_ANGLE_90
 #define VIPS_ANGLE_D180 VIPS_ANGLE_180
@@ -328,7 +325,7 @@ vips_watermark(VipsImage *in, VipsImage **out, WatermarkTextOptions *to, Waterma
 int
 vips_gaussblur_bridge(VipsImage *in, VipsImage **out, double sigma, double min_ampl) {
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
-	return vips_gaussblur(in, out, ceil(sigma), NULL);
+	return vips_gaussblur(in, out, (int) sigma, NULL);
 #else
 	return vips_gaussblur(in, out, sigma, NULL, "min_ampl", min_ampl, NULL);
 #endif

--- a/vips.h
+++ b/vips.h
@@ -16,7 +16,7 @@
  */
 
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
-/* we need math.h for ceil() in vips__gaussblur */
+/* we need math.h for ceil() in vips_gaussblur_bridge */
 #include <math.h>
 
 #define VIPS_ANGLE_D0 VIPS_ANGLE_0
@@ -326,7 +326,7 @@ vips_watermark(VipsImage *in, VipsImage **out, WatermarkTextOptions *to, Waterma
 }
 
 int
-vips__gaussblur(VipsImage *in, VipsImage **out, double sigma, double min_ampl) {
+vips_gaussblur_bridge(VipsImage *in, VipsImage **out, double sigma, double min_ampl) {
 #if (VIPS_MAJOR_VERSION == 7 && VIPS_MINOR_VERSION < 41)
 	return vips_gaussblur(in, out, ceil(sigma), NULL);
 #else


### PR DESCRIPTION
Hi @h2non 

This is a PR to add support for Gaussian Blur.
As always, there's a big difference between < 7.41 and >= 7.42.
I've tested with 7.40, works great, but I cannot test right now with 7.42 (I'll try in a docker soon).

Quick information on the PR:
- Maybe the way I've added the options are not the best, let me know how exactly you want it
- before 7.42, only one parameter (radius int), after, two parameters (sigma, min_ampl double)
- I've plugged the call in the transformImage and shouldTransformImage, maybe you want it elsewhere
- I used the vips_gaussblur method, maybe using a mask is more effective ? that could be something to test
- No test/bench right now, but I'll add it later, just opening the PR to get a feedback on previous points
- No documentation yet, same as above, I'll add it later once we are OK on the code itself

**It's not tested on vips >= 7.42, so any feedback on that will be of great help!**

Thanks!