### PR TITLE
Adding a Background option when flattening out a transparent PNG

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -246,6 +246,19 @@ func TestImageConvert(t *testing.T) {
 	Write("fixtures/test_image_convert_out.png", buf)
 }
 
+func TestTransparentImageConvert(t *testing.T) {
+	image := initImage("transparent.png")
+	options := Options{
+		Type:       JPEG,
+		Background: Color{255, 255, 255},
+	}
+	buf, err := image.Process(options)
+	if err != nil {
+		t.Errorf("Cannot process the image: %#v", err)
+	}
+	Write("fixtures/test_transparent_image_convert_out.jpg", buf)
+}
+
 func TestImageMetadata(t *testing.T) {
 	data, err := initImage("test.png").Metadata()
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -123,4 +123,5 @@ type Options struct {
 	Interpolator   Interpolator
 	Interpretation Interpretation
 	GaussianBlur   GaussianBlur
+	Background     Color
 }

--- a/resize.go
+++ b/resize.go
@@ -102,6 +102,15 @@ func Resize(buf []byte, o Options) ([]byte, error) {
 		return nil, err
 	}
 
+	// Flatten image on a background, if necessary
+	black := Color{0, 0, 0}
+	if imageType == PNG && o.Background != black {
+		image, err = vipsFlatten(image, o.Background)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	saveOptions := vipsSaveOptions{
 		Quality:        o.Quality,
 		Type:           o.Type,

--- a/vips.go
+++ b/vips.go
@@ -252,6 +252,16 @@ func vipsInterpretation(image *C.VipsImage) Interpretation {
 	return Interpretation(C.vips_image_guess_interpretation_bridge(image))
 }
 
+func vipsFlatten(image *C.VipsImage, background Color) (*C.VipsImage, error) {
+	var outImage *C.VipsImage
+	backgroundC := [3]C.double{C.double(background.R), C.double(background.G), C.double(background.B)}
+	err := int(C.vips_flatten_image(image, &outImage, (*C.double)(&backgroundC[0])))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+	return outImage, nil
+}
+
 func vipsPreSave(image *C.VipsImage, o *vipsSaveOptions) (*C.VipsImage, error) {
 	// Remove ICC profile metadata
 	if o.NoProfile {

--- a/vips.h
+++ b/vips.h
@@ -227,6 +227,15 @@ vips_webpsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 }
 
 int
+vips_flatten_image(VipsImage *in, VipsImage **out, double background[3]) {
+	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+	return vips_flatten(in, out,
+		"background", vipsBackground,
+		NULL
+	);
+}
+
+int
 vips_init_image (void *buf, size_t len, int imageType, VipsImage **out) {
 	int code = 1;
 


### PR DESCRIPTION
Hello !

I was converting a transparent PNG to JPEG and realized than it was always outputting the image with a black background. I just moved away from ImageMagick to your library to be (way) more lightweight and that's the only feature I was missing. 

So I added a `Background` Option and check whether the input is PNG before using `vips_flatten`. 
I tested with vips 8.0.2, not really with prior versions. I also added a unit test for that function. 

I'm not sure I'm respecting your standard here so please let me know by comments if you want me to do any further modifications.

Cheers.