### PR TITLE
Check for alpha channel before flattening image

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -274,13 +274,14 @@ func vipsFlattenBackground(image *C.VipsImage, background Color) (*C.VipsImage, 
 		C.double(background.B),
 	}
 
-	err := C.vips_flatten_background_brigde(image, &outImage, (*C.double)(&backgroundC[0]))
-	if int(err) != 0 {
-		return nil, catchVipsError()
+	if vipsHasAlpha(image) {
+		err := C.vips_flatten_background_brigde(image, &outImage, (*C.double)(&backgroundC[0]))
+		if int(err) != 0 {
+			return nil, catchVipsError()
+		}
+		C.g_object_unref(C.gpointer(image))
+		image = outImage
 	}
-
-	C.g_object_unref(C.gpointer(image))
-	image = outImage
 
 	return image, nil
 }


### PR DESCRIPTION
Vips return an error (linear: vector must have 1 or 2 elements) if vips_flatten is called with an image that has no alpha channel. Therefore, the image should be checked before calling this function.