### PR TITLE
Take care to not dereference the original image a second time

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -318,7 +318,12 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer C.g_object_unref(C.gpointer(tmpImage))
+	//When an image has an unsupported color space, vipsPreSave returns the pointer of the image passed to it unmodified.
+	//When this occurs, we must take care to not dereference the original image a second time;
+	//we may otherwise erroneously free the object twice
+	if tmpImage != image {
+		defer C.g_object_unref(C.gpointer(tmpImage))
+	}
 
 	length := C.size_t(0)
 	saveErr := C.int(0)


### PR DESCRIPTION
When an image has an unsupported color space, vipsPreSave returns the pointer of the image passed to it unmodified. When this occurs, we must take care to not dereference the original image a second time; we may otherwise erroneously free the object twice

I ran into this issue when running tests with PNG's. The resize tests would fail with the results below

```
(bimg:25377): GLib-GObject-WARNING **: instance of invalid non-instantiatable type `(null)'
SIGTRAP: trace trap
PC=0x7fcd5144ef9b m=4
signal arrived during cgo execution
goroutine 43 [syscall, locked to thread]:
runtime.cgocall(0x5c3d00, 0xc82045e3e8, 0xc800000000)
	/home/travis/.gimme/versions/go1.6.linux.amd64/src/runtime/cgocall.go:123 +0xc2 fp=0xc82045e398 sp=0xc82045e370
github.com/fastly/fst-bimg._Cfunc_vips_jpegsave_bridge(0x7fcd443a57f0, 0xc82002e168, 0xc820018730, 0x5000000001, 0x0, 0xc800000000)
	??:0 +0x61 fp=0xc82045e3e8 sp=0xc82045e398
github.com/fastly/fst-bimg.vipsSave(0x7fcd443a5660, 0x50, 0x6, 0x1, 0x0, 0x16, 0x0, 0x0, 0x0, 0x0, ...)
	github.com/fastly/fst-bimg/_test/_obj_test/vips.cgo1.go:373 +0xbda fp=0xc82045e4e0 sp=0xc82045e3e8
github.com/fastly/fst-bimg.Resize(0xc8205cc000, 0x2eede5, 0x2eefe5, 0x5dc, 0x3e8, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	github.com/fastly/fst-bimg/_test/_obj_test/resize.cgo1.go:144 +0x11eb fp=0xc82045ea90 sp=0xc82045e4e0
github.com/fastly/fst-bimg.TestResizeVerticalImage(0xc8200201b0)
	/home/travis/gopath/src/github.com/fastly/fst-bimg/resize_test.go:55 +0x1fe fp=0xc82045ff48 sp=0xc82045ea90
testing.tRunner(0xc8200201b0, 0x94bdc0)
	/home/travis/.gimme/versions/go1.6.linux.amd64/src/testing/testing.go:473 +0xdd fp=0xc82045ff80 sp=0xc82045ff48
```
