### PR TITLE
Release 1.0.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,6 +4,7 @@
 - fix(background): pass proper background RGB color for PNG image conversion.
 - feat(types): validate supported image types by current `libvips` compilation.
 - feat(types): consistent SVG image checking.
+- feat(api): add public functions `VipsIsTypeSupported()`, `IsImageTypeSupportedByVips()` and `IsSVGImage()`.
 
 ## 1.0.2 / 27-09-2016
 

--- a/History.md
+++ b/History.md
@@ -1,7 +1,14 @@
+## 1.0.3 / 28-09-2016
+
+- fix(#95): better image type inference and support check.
+- fix(background): pass proper background RGB color for PNG image conversion.
+- feat(types): validate supported image types by current `libvips` compilation.
+- feat(types): consistent SVG image checking.
+
 ## 1.0.2 / 27-09-2016
 
-- feat(#95): support GIF, SVG and PDF formats
-- fix(#108): auto-width and height calculations now round instead of floor
+- feat(#95): support GIF, SVG and PDF formats.
+- fix(#108): auto-width and height calculations now round instead of floor.
 
 ## 1.0.1 / 22-06-2016
 

--- a/resize.go
+++ b/resize.go
@@ -28,7 +28,7 @@ func Resize(buf []byte, o Options) ([]byte, error) {
 	// Clone and define default options
 	o = applyDefaults(o, imageType)
 
-	if IsTypeSupported(o.Type) == false {
+	if !IsTypeSupported(o.Type) {
 		return nil, errors.New("Unsupported image output type")
 	}
 

--- a/resize.go
+++ b/resize.go
@@ -330,7 +330,6 @@ func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsIm
 	if imageType != PNG || o.Background == ColorBlack {
 		return image, nil
 	}
-
 	return vipsFlattenBackground(image, o.Background)
 }
 

--- a/type.go
+++ b/type.go
@@ -61,6 +61,9 @@ var SupportedImageTypes = map[ImageType]bool{
 
 // isBinary checks if the given buffer is a binary file.
 func isBinary(buf []byte) bool {
+	if len(buf) < 24 {
+		return false
+	}
 	for i := 0; i < 24; i++ {
 		charCode, _ := utf8.DecodeRuneInString(string(buf[i]))
 		if charCode == 65533 || charCode <= 8 {

--- a/type.go
+++ b/type.go
@@ -30,8 +30,8 @@ const (
 type ImageType int
 
 var (
-	htmlCommentRegex = regexp.MustCompile("<!--([\\s\\S]*?)-->")
-	svgRegex         = regexp.MustCompile(`^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*>\s*)?<svg[^>]*>[^*]*<\/svg>\s*$`)
+	htmlCommentRegex = regexp.MustCompile("(?i)<!--([\\s\\S]*?)-->")
+	svgRegex         = regexp.MustCompile(`(?i)^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*>\s*)?<svg[^>]*>[^*]*<\/svg>\s*$`)
 )
 
 // ImageTypes stores as pairs of image types supported and its alias names.
@@ -75,7 +75,7 @@ func isBinary(buf []byte) bool {
 
 // IsSVGImage returns true if the given buffer is a valid SVG image.
 func IsSVGImage(buf []byte) bool {
-	return !isBinary(buf) && svgRegex.Match(htmlCommentRegex.ReplaceAll(buf, []byte{0}))
+	return !isBinary(buf) && svgRegex.Match(htmlCommentRegex.ReplaceAll(buf, []byte{}))
 }
 
 // DetermineImageType determines the image type format (jpeg, png, webp or tiff)

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package bimg
 
 // Version represents the current package semantic version.
-const Version = "1.0.2"
+const Version = "1.0.3"

--- a/vips.go
+++ b/vips.go
@@ -30,9 +30,37 @@ const VipsMajorVersion = int(C.VIPS_MAJOR_VERSION)
 // VipsMinorVersion exposes the current libvips minor version number
 const VipsMinorVersion = int(C.VIPS_MINOR_VERSION)
 
+// HasJPEGSupport exposes if the current libvips compilation
+// supports JPEG images.
+const HasJPEGSupport = int(C.VIPS_JPEG_SUPPORT) == 1
+
+// HasWEBPSupport exposes if the current libvips compilation
+// supports WEBP images.
+const HasWEBPSupport = int(C.VIPS_WEBP_SUPPORT) == 1
+
+// HasPNGSupport exposes if the current libvips compilation
+// supports PNG images.
+const HasPNGSupport = int(C.VIPS_PNG_SUPPORT) == 1
+
 // HasMagickSupport exposes if the current libvips compilation
 // supports libmagick bindings.
 const HasMagickSupport = int(C.VIPS_MAGICK_SUPPORT) == 1
+
+// HasGIFSupport exposes if the current libvips compilation
+// supports GIF images.
+const HasGIFSupport = int(C.VIPS_GIF_SUPPORT) == 1
+
+// HasSVGSupport exposes if the current libvips compilation
+// supports SVG images.
+const HasSVGSupport = int(C.VIPS_SVG_SUPPORT) == 1
+
+// HasPDFSupport exposes if the current libvips compilation
+// supports PDF images.
+const HasPDFSupport = int(C.VIPS_PDF_SUPPORT) == 1
+
+// HasTIFFSupport exposes if the current libvips compilation
+// supports TIFF images.
+const HasTIFFSupport = int(C.VIPS_TIFF_SUPPORT) == 1
 
 const (
 	maxCacheMem  = 100 * 1024 * 1024
@@ -461,39 +489,36 @@ func vipsAffine(input *C.VipsImage, residualx, residualy float64, i Interpolator
 	return image, nil
 }
 
-func vipsImageType(bytes []byte) ImageType {
-	if len(bytes) == 0 {
+func vipsImageType(buf []byte) ImageType {
+	if len(buf) == 0 {
 		return UNKNOWN
 	}
 
-	if bytes[0] == 0x89 && bytes[1] == 0x50 && bytes[2] == 0x4E && bytes[3] == 0x47 {
+	if buf[0] == 0x89 && buf[1] == 0x50 && buf[2] == 0x4E && buf[3] == 0x47 {
 		return PNG
 	}
-	if bytes[0] == 0xFF && bytes[1] == 0xD8 && bytes[2] == 0xFF {
+	if buf[0] == 0xFF && buf[1] == 0xD8 && buf[2] == 0xFF {
 		return JPEG
 	}
-	if bytes[8] == 0x57 && bytes[9] == 0x45 && bytes[10] == 0x42 && bytes[11] == 0x50 {
+	if buf[8] == 0x57 && buf[9] == 0x45 && buf[10] == 0x42 && buf[11] == 0x50 {
 		return WEBP
 	}
-	if (bytes[0] == 0x49 && bytes[1] == 0x49 && bytes[2] == 0x2A && bytes[3] == 0x0) ||
-		(bytes[0] == 0x4D && bytes[1] == 0x4D && bytes[2] == 0x0 && bytes[3] == 0x2A) {
+	if (buf[0] == 0x49 && buf[1] == 0x49 && buf[2] == 0x2A && buf[3] == 0x0) ||
+		(buf[0] == 0x4D && buf[1] == 0x4D && buf[2] == 0x0 && buf[3] == 0x2A) {
 		return TIFF
 	}
-	if bytes[0] == 'G' && bytes[1] == 'I' && bytes[2] == 'F' && bytes[3] == '8' &&
-		bytes[4] == '9' && bytes[5] == 'a' {
+	if buf[0] == 0x47 && buf[1] == 0x49 && buf[2] == 0x46 {
 		return GIF
 	}
-	if bytes[0] == '%' && bytes[1] == 'P' && bytes[2] == 'D' && bytes[3] == 'F' {
+	if buf[0] == 0x25 && buf[1] == 0x50 && buf[2] == 0x44 && buf[3] == 0x46 {
 		return PDF
 	}
-	if bytes[0] == '<' && bytes[1] == '?' && bytes[2] == 'x' && bytes[3] == 'm' &&
-		bytes[4] == 'l' && bytes[5] == ' ' {
+	if IsSVGImage(buf) {
 		return SVG
 	}
-	if HasMagickSupport && strings.HasSuffix(readImageType(bytes), "MagickBuffer") {
+	if HasMagickSupport && strings.HasSuffix(readImageType(buf), "MagickBuffer") {
 		return MAGICK
 	}
-
 	return UNKNOWN
 }
 

--- a/vips.go
+++ b/vips.go
@@ -304,7 +304,8 @@ func vipsFlattenBackground(image *C.VipsImage, background Color) (*C.VipsImage, 
 	}
 
 	if vipsHasAlpha(image) {
-		err := C.vips_flatten_background_brigde(image, &outImage, (*C.double)(&backgroundC[0]))
+		err := C.vips_flatten_background_brigde(image, &outImage,
+			backgroundC[0], backgroundC[1], backgroundC[2])
 		if int(err) != 0 {
 			return nil, catchVipsError()
 		}

--- a/vips.h
+++ b/vips.h
@@ -3,54 +3,6 @@
 #include <vips/foreign.h>
 #include <vips/vips7compat.h>
 
-#ifdef  VIPS_MAGICK_H
-#define VIPS_MAGICK_SUPPORT 1
-#else
-#define VIPS_MAGICK_SUPPORT 0
-#endif
-
-#ifdef  HAVE_JPEG
-#define VIPS_JPEG_SUPPORT 1
-#else
-#define VIPS_JPEG_SUPPORT 0
-#endif
-
-#ifdef  HAVE_PNG
-#define VIPS_PNG_SUPPORT 1
-#else
-#define VIPS_PNG_SUPPORT 0
-#endif
-
-#ifdef  HAVE_LIBWEBP
-#define VIPS_WEBP_SUPPORT 1
-#else
-#define VIPS_WEBP_SUPPORT 0
-#endif
-
-#ifdef  HAVE_GIFLIB
-#define VIPS_GIF_SUPPORT 1
-#else
-#define VIPS_GIF_SUPPORT 0
-#endif
-
-#ifdef  HAVE_RSVG
-#define VIPS_SVG_SUPPORT 1
-#else
-#define VIPS_SVG_SUPPORT 0
-#endif
-
-#ifdef  HAVE_POPPLER
-#define VIPS_PDF_SUPPORT 1
-#else
-#define VIPS_PDF_SUPPORT 0
-#endif
-
-#ifdef  HAVE_TIFF
-#define VIPS_TIFF_SUPPORT 1
-#else
-#define VIPS_TIFF_SUPPORT 0
-#endif
-
 /**
  * Starting libvips 7.41, VIPS_ANGLE_x has been renamed to VIPS_ANGLE_Dx
  * "to help python". So we provide the macro to correctly build for versions
@@ -161,6 +113,35 @@ vips_flip_bridge(VipsImage *in, VipsImage **out, int direction) {
 int
 vips_shrink_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrink) {
 	return vips_shrink(in, out, xshrink, yshrink, NULL);
+}
+
+int
+vips_type_find_bridge(int t) {
+	if (t == GIF) {
+		return vips_type_find("VipsOperation", "gifload");
+	}
+	if (t == PDF) {
+		return vips_type_find("VipsOperation", "pdfload");
+	}
+	if (t == TIFF) {
+		return vips_type_find("VipsOperation", "tiffload");
+	}
+	if (t == SVG) {
+		return vips_type_find("VipsOperation", "svgload");
+	}
+	if (t == WEBP) {
+		return vips_type_find("VipsOperation", "webpload");
+	}
+	if (t == PNG) {
+		return vips_type_find("VipsOperation", "pngload");
+	}
+	if (t == JPEG) {
+		return vips_type_find("VipsOperation", "jpegload");
+	}
+	if (t == MAGICK) {
+		return vips_type_find("VipsOperation", "magickload");
+	}
+	return 0;
 }
 
 int

--- a/vips.h
+++ b/vips.h
@@ -277,12 +277,10 @@ vips_is_16bit (VipsInterpretation interpretation) {
 }
 
 int
-vips_flatten_background_brigde(VipsImage *in, VipsImage **out, double background[3]) {
-	background[0] *= 256;
-	background[1] *= 256;
-	background[2] *= 256;
-
+vips_flatten_background_brigde(VipsImage *in, VipsImage **out, double r, double g, double b) {
+	double background[3] = {r, g, b};
 	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+	
 	return vips_flatten(in, out,
 		"background", vipsBackground,
 		"max_alpha", vips_is_16bit(in->Type) ? 65535.0 : 255.0,

--- a/vips.h
+++ b/vips.h
@@ -1,11 +1,54 @@
 #include <stdlib.h>
 #include <vips/vips.h>
+#include <vips/foreign.h>
 #include <vips/vips7compat.h>
 
 #ifdef  VIPS_MAGICK_H
 #define VIPS_MAGICK_SUPPORT 1
 #else
 #define VIPS_MAGICK_SUPPORT 0
+#endif
+
+#ifdef  HAVE_JPEG
+#define VIPS_JPEG_SUPPORT 1
+#else
+#define VIPS_JPEG_SUPPORT 0
+#endif
+
+#ifdef  HAVE_PNG
+#define VIPS_PNG_SUPPORT 1
+#else
+#define VIPS_PNG_SUPPORT 0
+#endif
+
+#ifdef  HAVE_LIBWEBP
+#define VIPS_WEBP_SUPPORT 1
+#else
+#define VIPS_WEBP_SUPPORT 0
+#endif
+
+#ifdef  HAVE_GIFLIB
+#define VIPS_GIF_SUPPORT 1
+#else
+#define VIPS_GIF_SUPPORT 0
+#endif
+
+#ifdef  HAVE_RSVG
+#define VIPS_SVG_SUPPORT 1
+#else
+#define VIPS_SVG_SUPPORT 0
+#endif
+
+#ifdef  HAVE_POPPLER
+#define VIPS_PDF_SUPPORT 1
+#else
+#define VIPS_PDF_SUPPORT 0
+#endif
+
+#ifdef  HAVE_TIFF
+#define VIPS_TIFF_SUPPORT 1
+#else
+#define VIPS_TIFF_SUPPORT 0
 #endif
 
 /**


### PR DESCRIPTION
- fix(#95): better image type inference and support check.
- fix(background): pass proper background RGB color for PNG image conversion.
- feat(types): validate supported image types by current `libvips` compilation.
- feat(types): consistent SVG image type checking.
- feat(api): add public functions `VipsIsTypeSupported()`, `IsImageTypeSupportedByVips()` and `IsSVGImage()`.