### PR TITLE
Add support for image watermarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 /*.png
 /*.webp
 /fixtures/*_out.*
+/.idea/

--- a/image.go
+++ b/image.go
@@ -124,6 +124,12 @@ func (i *Image) Watermark(w Watermark) ([]byte, error) {
 	return i.Process(options)
 }
 
+// WatermarkImage adds image as watermark on the given image.
+func (i *Image) WatermarkImage(w WatermarkImage) ([]byte, error) {
+	options := Options{WatermarkImage: w}
+	return i.Process(options)
+}
+
 // Zoom zooms the image by the given factor.
 // You should probably call Extract() before.
 func (i *Image) Zoom(factor int) ([]byte, error) {

--- a/image_test.go
+++ b/image_test.go
@@ -239,7 +239,34 @@ func TestImageWatermark(t *testing.T) {
 		t.Fatal("Image is not jpeg")
 	}
 
-	Write("fixtures/test_watermark_out.jpg", buf)
+	Write("fixtures/test_watermark_text_out.jpg", buf)
+}
+
+func TestImageWatermarkWithImage(t *testing.T) {
+	image := initImage("test.jpg")
+	watermark, _ := imageBuf("transparent.png")
+
+	_, err := image.Crop(800, 600, GravityNorth)
+	if err != nil {
+		t.Errorf("Cannot process the image: %#v", err)
+	}
+
+	buf, err := image.WatermarkImage(WatermarkImage{Left: 100, Top: 100, Buf: watermark})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = assertSize(buf, 800, 600)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if DetermineImageType(buf) != JPEG {
+		t.Fatal("Image is not jpeg")
+	}
+
+	Write("fixtures/test_watermark_image_out.jpg", buf)
 }
 
 func TestImageWatermarkNoReplicate(t *testing.T) {
@@ -429,8 +456,12 @@ func TestFluentInterface(t *testing.T) {
 }
 
 func initImage(file string) *Image {
-	buf, _ := Read(path.Join("fixtures", file))
+	buf, _ := imageBuf(file)
 	return NewImage(buf)
+}
+
+func imageBuf(file string) ([]byte, error) {
+	return Read(path.Join("fixtures", file))
 }
 
 func assertSize(buf []byte, width, height int) error {

--- a/options.go
+++ b/options.go
@@ -157,6 +157,14 @@ type Watermark struct {
 	Background  Color
 }
 
+// WatermarkImage represents the image-based watermark supported options.
+type WatermarkImage struct {
+	Left    int
+	Top     int
+	Buf     []byte
+	Opacity float32
+}
+
 // GaussianBlur represents the gaussian image transformation values.
 type GaussianBlur struct {
 	Sigma   float64
@@ -198,6 +206,7 @@ type Options struct {
 	Background     Color
 	Gravity        Gravity
 	Watermark      Watermark
+	WatermarkImage WatermarkImage
 	Type           ImageType
 	Interpolator   Interpolator
 	Interpretation Interpretation

--- a/resize_test.go
+++ b/resize_test.go
@@ -72,7 +72,7 @@ func TestResizeVerticalImage(t *testing.T) {
 			t.Fatalf("Invalid width: %d", size.Width)
 		}
 
-		Write("fixtures/test_vertical_"+strconv.Itoa(test.options.Width)+"x"+strconv.Itoa(test.options.Height)+".jpg", image)
+		Write("fixtures/test_vertical_"+strconv.Itoa(test.options.Width)+"x"+strconv.Itoa(test.options.Height)+"_out.jpg", image)
 	}
 }
 
@@ -264,7 +264,7 @@ func TestGaussianBlur(t *testing.T) {
 		t.Fatalf("Invalid image size: %dx%d", size.Width, size.Height)
 	}
 
-	Write("fixtures/test_gaussian.jpg", newImg)
+	Write("fixtures/test_gaussian_out.jpg", newImg)
 }
 
 func TestSharpen(t *testing.T) {
@@ -281,7 +281,7 @@ func TestSharpen(t *testing.T) {
 		t.Fatalf("Invalid image size: %dx%d", size.Width, size.Height)
 	}
 
-	Write("fixtures/test_sharpen.jpg", newImg)
+	Write("fixtures/test_sharpen_out.jpg", newImg)
 }
 
 func TestExtractWithDefaultAxis(t *testing.T) {
@@ -298,7 +298,7 @@ func TestExtractWithDefaultAxis(t *testing.T) {
 		t.Fatalf("Invalid image size: %dx%d", size.Width, size.Height)
 	}
 
-	Write("fixtures/test_extract_defaults.jpg", newImg)
+	Write("fixtures/test_extract_defaults_out.jpg", newImg)
 }
 
 func TestExtractCustomAxis(t *testing.T) {
@@ -315,7 +315,7 @@ func TestExtractCustomAxis(t *testing.T) {
 		t.Fatalf("Invalid image size: %dx%d", size.Width, size.Height)
 	}
 
-	Write("fixtures/test_extract_custom_axis.jpg", newImg)
+	Write("fixtures/test_extract_custom_axis_out.jpg", newImg)
 }
 
 func TestConvert(t *testing.T) {
@@ -553,6 +553,45 @@ func BenchmarkWatermarWebp(b *testing.B) {
 			Margin:     150,
 			Font:       "sans bold 12",
 			Background: Color{255, 255, 255},
+		},
+	}
+	runBenchmarkResize("test.webp", options, b)
+}
+
+func BenchmarkWatermarkImageJpeg(b *testing.B) {
+	watermark := readFile("transparent.png")
+	options := Options{
+		WatermarkImage: WatermarkImage{
+			Buf:     watermark,
+			Opacity: 0.25,
+			Left:    100,
+			Top:     100,
+		},
+	}
+	runBenchmarkResize("test.jpg", options, b)
+}
+
+func BenchmarkWatermarImagePng(b *testing.B) {
+	watermark := readFile("transparent.png")
+	options := Options{
+		WatermarkImage: WatermarkImage{
+			Buf:     watermark,
+			Opacity: 0.25,
+			Left:    100,
+			Top:     100,
+		},
+	}
+	runBenchmarkResize("test.png", options, b)
+}
+
+func BenchmarkWatermarImageWebp(b *testing.B) {
+	watermark := readFile("transparent.png")
+	options := Options{
+		WatermarkImage: WatermarkImage{
+			Buf:     watermark,
+			Opacity: 0.25,
+			Left:    100,
+			Top:     100,
 		},
 	}
 	runBenchmarkResize("test.webp", options, b)

--- a/vips.go
+++ b/vips.go
@@ -67,6 +67,12 @@ type vipsWatermarkOptions struct {
 	Background  [3]C.double
 }
 
+type vipsWatermarkImageOptions struct {
+	Left    C.int
+	Top     C.int
+	Opacity C.float
+}
+
 type vipsWatermarkTextOptions struct {
 	Text *C.char
 	Font *C.char
@@ -588,4 +594,26 @@ func vipsSharpen(image *C.VipsImage, o Sharpen) (*C.VipsImage, error) {
 
 func max(x int) int {
 	return int(math.Max(float64(x), 0))
+}
+
+func vipsDrawWatermark(image *C.VipsImage, watermark *C.VipsImage, o WatermarkImage) (*C.VipsImage, error) {
+	var out *C.VipsImage
+
+	if !vipsHasAlpha(image) {
+		C.vips_add_band(image, &image, C.double(255.0))
+	}
+
+	if !vipsHasAlpha(watermark) {
+		C.vips_add_band(watermark, &watermark, C.double(255.0))
+	}
+
+	opts := vipsWatermarkImageOptions{C.int(o.Left), C.int(o.Top), C.float(o.Opacity)}
+
+	err := C.vips_watermark_image(image, watermark, &out, (*C.WatermarkImageOptions)(unsafe.Pointer(&opts)))
+
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+
+	return out, nil
 }

--- a/vips_test.go
+++ b/vips_test.go
@@ -114,9 +114,26 @@ func TestVipsWatermark(t *testing.T) {
 		t.Errorf("Cannot add watermark: %s", err)
 	}
 
-	buf, err := vipsSave(newImg, vipsSaveOptions{Quality: 95})
-	if len(buf) == 0 || err != nil {
-		t.Fatalf("Empty image. %#v", err)
+	buf, _ := vipsSave(newImg, vipsSaveOptions{Quality: 95})
+	if len(buf) == 0 {
+		t.Fatal("Empty image")
+	}
+}
+
+func TestVipsWatermarkWithImage(t *testing.T) {
+	image, _, _ := vipsRead(readImage("test.jpg"))
+
+	watermark, _, _ := vipsRead(readImage("transparent.png"))
+
+	options := WatermarkImage{Left: 100, Top: 100, Opacity: 1.0}
+	newImg, err := vipsDrawWatermark(image, watermark, options)
+	if err != nil {
+		t.Errorf("Cannot add watermark: %s", err)
+	}
+
+	buf, _ := vipsSave(newImg, vipsSaveOptions{Quality: 95})
+	if len(buf) == 0 {
+		t.Fatal("Empty image")
 	}
 }
 


### PR DESCRIPTION
Hi!, 
This PR adds support for embedding images as watermarks. Like the example below.
![test_watermark_draw_out](https://cloud.githubusercontent.com/assets/8705733/22260486/aced6a94-e269-11e6-9876-8c53fc9b2863.jpg)

It allows you to specify the Left and Top position and also the Opacity of the watermark.

```go
type WatermarkImage struct {
	Left    int
 	Top     int
 	Buf     []byte
 	Opacity float32
 }

```

Regards!
