### PR TITLE
Use vips reduce when downscaling

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -198,7 +198,11 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 	}
 
 	if o.Force || residual != 0 {
-		image, err = vipsAffine(image, residualx, residualy, o.Interpolator)
+		if residualx < 1 && residualy < 1 {
+			image, err = vipsReduce(image, 1/residualx, 1/residualy)
+		} else {
+			image, err = vipsAffine(image, residualx, residualy, o.Interpolator)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/vips.go
+++ b/vips.go
@@ -513,6 +513,18 @@ func vipsShrink(input *C.VipsImage, shrink int) (*C.VipsImage, error) {
 	return image, nil
 }
 
+func vipsReduce(input *C.VipsImage, xshrink float64, yshrink float64) (*C.VipsImage, error) {
+	var image *C.VipsImage
+	defer C.g_object_unref(C.gpointer(input))
+
+	err := C.vips_reduce_bridge(input, &image, C.double(xshrink), C.double(yshrink))
+	if err != 0 {
+		return nil, catchVipsError()
+	}
+
+	return image, nil
+}
+
 func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, background Color) (*C.VipsImage, error) {
 	var image *C.VipsImage
 

--- a/vips.h
+++ b/vips.h
@@ -123,6 +123,11 @@ vips_shrink_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrin
 }
 
 int
+vips_reduce_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrink) {
+	return vips_reduce(in, out, xshrink, yshrink, NULL);
+}
+
+int
 vips_type_find_bridge(int t) {
 	if (t == GIF) {
 		return vips_type_find("VipsOperation", "gifload");


### PR DESCRIPTION
I'm scaling an image down by about half and it seems bimg is using vips_affine to do the downscaling, which results in really aliased images:
![image](https://cloud.githubusercontent.com/assets/2247982/24089913/bb9dc6e6-0d8f-11e7-9d07-11792359a24b.png)


Instead I've swapped it to use vips_reduce when downscaling:
![image](https://cloud.githubusercontent.com/assets/2247982/24089881/5f2efb1e-0d8f-11e7-98ec-9f4f45439d47.png)

I think this would fix https://github.com/h2non/bimg/issues/94