### PR TITLE
Make sure the buf is not GCed in Resize method.

### DIFF
--- a/resize.go
+++ b/resize.go
@@ -9,12 +9,14 @@ import "C"
 import (
 	"errors"
 	"math"
+  "runtime"
 )
 
 // Resize is used to transform a given image as byte buffer
 // with the passed options.
 func Resize(buf []byte, o Options) ([]byte, error) {
 	defer C.vips_thread_shutdown()
+  defer runtime.KeepAlive(buf)
 
 	image, imageType, err := loadImage(buf)
 

--- a/resize.go
+++ b/resize.go
@@ -8,7 +8,7 @@ import "C"
 
 import (
 	"errors"
-	"math"
+  "math"
   "runtime"
 )
 

--- a/resize.go
+++ b/resize.go
@@ -15,7 +15,7 @@ import (
 // Resize is used to transform a given image as byte buffer
 // with the passed options.
 func Resize(buf []byte, o Options) ([]byte, error) {
-	defer C.vips_thread_shutdown()
+  defer C.vips_thread_shutdown()
   defer runtime.KeepAlive(buf)
 
 	image, imageType, err := loadImage(buf)


### PR DESCRIPTION
If someone calls Resize directly, the but input could be GCed too early. Use runtime.KeepAlive to make sure the buf is not GCed.