### PR TITLE
Add option to convert embedded ICC profiles

### DIFF
--- a/options.go
+++ b/options.go
@@ -215,4 +215,5 @@ type Options struct {
 	Interpretation Interpretation
 	GaussianBlur   GaussianBlur
 	Sharpen        Sharpen
+	OutputICC      string
 }

--- a/resize.go
+++ b/resize.go
@@ -161,6 +161,7 @@ func saveImage(image *C.VipsImage, o Options) ([]byte, error) {
 		Interlace:      o.Interlace,
 		NoProfile:      o.NoProfile,
 		Interpretation: o.Interpretation,
+		OutputICC:      o.OutputICC,
 	}
 	// Finally get the resultant buffer
 	return vipsSave(image, saveOptions)

--- a/vips.h
+++ b/vips.h
@@ -261,6 +261,12 @@ vips_colourspace_bridge(VipsImage *in, VipsImage **out, VipsInterpretation space
 }
 
 int
+vips_icc_transform_bridge (VipsImage *in, VipsImage **out, const char *output_icc_profile) {
+	// `output_icc_profile` represents the absolute path to the output ICC profile file
+	return vips_icc_transform(in, out, output_icc_profile, "embedded", TRUE, NULL);
+}
+
+int
 vips_jpegsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int quality, int interlace) {
 	return vips_jpegsave_buffer(in, buf, len,
 		"strip", strip,


### PR DESCRIPTION
Set an bimg.Options OutputICC to an absolute path to the desired output ICC profile. If an embedded ICC profile is found in VipsImage, it is converted to the output ICC profile.
Fixes #50


Please let me know what you think about this.

/cc @tback