### PR TITLE
Fix memory leak on icc_transform

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -394,6 +394,7 @@ func vipsPreSave(image *C.VipsImage, o *vipsSaveOptions) (*C.VipsImage, error) {
 		if int(err) != 0 {
 			return nil, catchVipsError()
 		}
+		C.g_object_unref(C.gpointer(image))
 		image = outImage
 	}
 


### PR DESCRIPTION
With #168 I've introduced a memory leak when `vips_icc_transform` was used (when `OutputICC` option was defined).

