### PR TITLE
Fix Image.Enlarge keep image size in boundaries

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -129,17 +129,27 @@ func TestImageExtractZero(t *testing.T) {
 }
 
 func TestImageEnlarge(t *testing.T) {
-	buf, err := initImage("test.png").Enlarge(500, 375)
-	if err != nil {
-		t.Errorf("Cannot process the image: %#v", err)
+	tests := []struct {
+		input    []int
+		expected []int
+	}{
+		{[]int{500, 375}, []int{500, 375}},
+		{[]int{577, 1250}, []int{577, 433}},
 	}
 
-	err = assertSize(buf, 500, 375)
-	if err != nil {
-		t.Error(err)
-	}
+	for c, test := range tests {
+		buf, err := initImage("test.png").Enlarge(test.input[0], test.input[1])
+		if err != nil {
+			t.Errorf("Cannot process the image: %#v", err)
+		}
 
-	Write("testdata/test_enlarge_out.jpg", buf)
+		err = assertSize(buf, test.expected[0], test.expected[1])
+		if err != nil {
+			t.Error(err)
+		}
+
+		Write(fmt.Sprintf("testdata/test_enlarge_out_%d.jpg", c), buf)
+	}
 }
 
 func TestImageEnlargeAndCrop(t *testing.T) {

--- a/resizer.go
+++ b/resizer.go
@@ -453,7 +453,13 @@ func imageCalculations(o *Options, inWidth, inHeight int) float64 {
 	switch {
 	// Fixed width and height
 	case o.Width > 0 && o.Height > 0:
-		factor = math.Min(xfactor, yfactor)
+		// Use minimum factor for croping or downscaling
+		// use maximum factor for upscaling
+		if o.Crop || (o.Width < inWidth || o.Height < inHeight) {
+			factor = math.Min(xfactor, yfactor)
+		} else {
+			factor = math.Max(xfactor, yfactor)
+		}
 	// Fixed width, auto height
 	case o.Width > 0:
 		if o.Crop {


### PR DESCRIPTION
Image.Enlarge does not always return an image that fits into the given
width and height boundaries.

To fix that, imageCalculations() now returns the maximum factor instead
if the minimum if no cropping is requested and the desired image is
bigger than the source.

Im not completely sure with this but I expected `Image.Enlarge` to always return images that don't exceed the width and height provided.

/cc @tback