### PR TITLE
Add the option to use background and threshold options on trim

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -517,7 +517,7 @@ func TestImageTrimParameters(t *testing.T) {
 		t.Errorf("The image wasn't trimmed.")
 	}
 
-	Write("testdata/transparent_trim.png", buf)
+	Write("testdata/parameter_trim.png", buf)
 }
 
 func TestImageLength(t *testing.T) {

--- a/image_test.go
+++ b/image_test.go
@@ -495,6 +495,31 @@ func TestImageTrim(t *testing.T) {
 	Write("testdata/transparent_trim.png", buf)
 }
 
+func TestImageTrimParameters(t *testing.T) {
+
+	if !(VipsMajorVersion >= 8 && VipsMinorVersion >= 6) {
+		t.Skipf("Skipping this test, libvips doesn't meet version requirement %s >= 8.6", VipsVersion)
+	}
+
+	i := initImage("test.png")
+	options := Options{
+		Trim:       true,
+		Background: Color{0.0, 0.0, 0.0},
+		Threshold:  10.0,
+	}
+	buf, err := i.Process(options)
+	if err != nil {
+		t.Errorf("Cannot process the image: %#v", err)
+	}
+
+	err = assertSize(buf, 400, 257)
+	if err != nil {
+		t.Errorf("The image wasn't trimmed.")
+	}
+
+	Write("testdata/transparent_trim.png", buf)
+}
+
 func TestImageLength(t *testing.T) {
 	i := initImage("test.jpg")
 

--- a/options.go
+++ b/options.go
@@ -217,5 +217,6 @@ type Options struct {
 	Interpretation Interpretation
 	GaussianBlur   GaussianBlur
 	Sharpen        Sharpen
+	Threshold      float32
 	OutputICC      string
 }

--- a/resizer.go
+++ b/resizer.go
@@ -273,7 +273,7 @@ func extractOrEmbedImage(image *C.VipsImage, o Options) (*C.VipsImage, error) {
 		image, err = vipsEmbed(image, left, top, o.Width, o.Height, o.Extend, o.Background)
 		break
 	case o.Trim:
-		left, top, width, height, err := vipsTrim(image)
+		left, top, width, height, err := vipsTrim(image, o.Background, o.Threshold)
 		if err == nil {
 			image, err = vipsExtract(image, left, top, width, height)
 		}

--- a/vips.go
+++ b/vips.go
@@ -503,7 +503,7 @@ func vipsSmartCrop(image *C.VipsImage, width, height int) (*C.VipsImage, error) 
 	return buf, nil
 }
 
-func vipsTrim(image *C.VipsImage) (int, int, int, int, error) {
+func vipsTrim(image *C.VipsImage, background Color, threshold float32) (int, int, int, int, error) {
 	defer C.g_object_unref(C.gpointer(image))
 
 	top := C.int(0)
@@ -511,7 +511,10 @@ func vipsTrim(image *C.VipsImage) (int, int, int, int, error) {
 	width := C.int(0)
 	height := C.int(0)
 
-	err := C.vips_find_trim_bridge(image, &top, &left, &width, &height)
+	err := C.vips_find_trim_bridge(image,
+		&top, &left, &width, &height,
+		C.double(background.R), C.double(background.G), C.double(background.B),
+		C.double(threshold))
 	if err != 0 {
 		return 0, 0, 0, 0, catchVipsError()
 	}

--- a/vips.h
+++ b/vips.h
@@ -545,9 +545,17 @@ vips_smartcrop_bridge(VipsImage *in, VipsImage **out, int width, int height) {
 #endif
 }
 
-int vips_find_trim_bridge(VipsImage *in, int *top, int *left, int *width, int *height) {
+int vips_find_trim_bridge(VipsImage *in, int *top, int *left, int *width, int *height, double r, double g, double b, double threshold) {
 #if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 6)
-	return vips_find_trim(in, top, left, width, height, NULL);
+	if (vips_is_16bit(in->Type)) {
+		r = 65535 * r / 255;
+		g = 65535 * g / 255;
+		b = 65535 * b / 255;
+	}
+
+	double background[3] = {r, g, b};
+	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+	return vips_find_trim(in, top, left, width, height, "background", vipsBackground, "threshold", threshold, NULL);
 #else
 	return 0;
 #endif


### PR DESCRIPTION
The trim function in libvips accepts optional parameters Background and Threshold, which can be quite important when trimming an image. The background is used to choose the color to actually trim away, and threshold is the amount of difference allowed, see [here](https://github.com/jcupitt/libvips/blob/f6db350a1e56e258e0a4e6ad6ee33b730b93b1c5/libvips/arithmetic/find_trim.c#L239-L274)

This should add those parameters, directly from the Options struct just as other such parameters.

One extra thing to add would be to have an option to detect the color to be used from ie. the top left pixel, to work with previously unknown images. This is also a feature I need.