### PR TITLE
Add lossless option for saving webp

### DIFF
--- a/options.go
+++ b/options.go
@@ -206,6 +206,7 @@ type Options struct {
 	Interlace      bool
 	StripMetadata  bool
 	Trim           bool
+	Lossless       bool
 	Extend         Extend
 	Rotate         Angle
 	Background     Color

--- a/resizer.go
+++ b/resizer.go
@@ -165,6 +165,7 @@ func saveImage(image *C.VipsImage, o Options) ([]byte, error) {
 		Interpretation: o.Interpretation,
 		OutputICC:      o.OutputICC,
 		StripMetadata:  o.StripMetadata,
+		Lossless:       o.Lossless,
 	}
 	// Finally get the resultant buffer
 	return vipsSave(image, saveOptions)

--- a/vips.go
+++ b/vips.go
@@ -56,6 +56,7 @@ type vipsSaveOptions struct {
 	Interlace      bool
 	NoProfile      bool
 	StripMetadata  bool
+	Lossless       bool
 	OutputICC      string // Absolute path to the output ICC profile
 	Interpretation Interpretation
 }
@@ -423,6 +424,7 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 	interlace := C.int(boolToInt(o.Interlace))
 	quality := C.int(o.Quality)
 	strip := C.int(boolToInt(o.StripMetadata))
+	lossless := C.int(boolToInt(o.Lossless))
 
 	if o.Type != 0 && !IsTypeSupportedSave(o.Type) {
 		return nil, fmt.Errorf("VIPS cannot save to %#v", ImageTypes[o.Type])
@@ -430,7 +432,7 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 	var ptr unsafe.Pointer
 	switch o.Type {
 	case WEBP:
-		saveErr = C.vips_webpsave_bridge(tmpImage, &ptr, &length, strip, quality)
+		saveErr = C.vips_webpsave_bridge(tmpImage, &ptr, &length, strip, quality, lossless)
 	case PNG:
 		saveErr = C.vips_pngsave_bridge(tmpImage, &ptr, &length, strip, C.int(o.Compression), quality, interlace)
 	case TIFF:

--- a/vips.h
+++ b/vips.h
@@ -306,10 +306,11 @@ vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compr
 }
 
 int
-vips_webpsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int quality) {
+vips_webpsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int quality, int lossless) {
 	return vips_webpsave_buffer(in, buf, len,
 		"strip", INT_TO_GBOOLEAN(strip),
 		"Q", quality,
+		"lossless", INT_TO_GBOOLEAN(lossless),
 		NULL
 	);
 }


### PR DESCRIPTION
Surfacing option to save webp images in lossless mode.

Looking at libvips this param has been available for quite some time ([7.38 I think](https://github.com/jcupitt/libvips/blob/7.38/libvips/foreign/webpsave.c#L61)) so didn't wrap it in a version conditional.

Just testing the water but if this looks ok I could have a go at surfacing some of the other webp options mentioned in #135 like 

- `o.NearLossless`
- `o.AlphaQuality`
- `o.SmartSubsample` 

and potentially

- `o.WebpPreset` enum

Let me know if that's ok, along with the naming, and I can give it a shot.
