### PR TITLE
fixing text position

### DIFF
--- a/options.go
+++ b/options.go
@@ -152,6 +152,8 @@ var ColorBlack = Color{0, 0, 0}
 
 // Watermark represents the text-based watermark supported options.
 type Watermark struct {
+	Left int
+	Top int
 	Width       int
 	DPI         int
 	Margin      int

--- a/vips.go
+++ b/vips.go
@@ -57,6 +57,8 @@ type vipsSaveOptions struct {
 }
 
 type vipsWatermarkOptions struct {
+	Left				C.int
+	Top 				C.int
 	Width       C.int
 	DPI         C.int
 	Margin      C.int
@@ -279,7 +281,9 @@ func vipsWatermark(image *C.VipsImage, w Watermark) (*C.VipsImage, error) {
 	background := [3]C.double{C.double(w.Background.R), C.double(w.Background.G), C.double(w.Background.B)}
 
 	textOpts := vipsWatermarkTextOptions{text, font}
-	opts := vipsWatermarkOptions{C.int(w.Width), C.int(w.DPI), C.int(w.Margin), C.int(noReplicate), C.float(w.Opacity), background}
+	opts := vipsWatermarkOptions{C.int(w.Left), C.int(w.Top),C.int(w.Width), C.int(w.DPI),
+	C.int(w.Margin),
+	C.int(noReplicate), C.float(w.Opacity), background}
 
 	defer C.free(unsafe.Pointer(text))
 	defer C.free(unsafe.Pointer(font))

--- a/vips.h
+++ b/vips.h
@@ -41,6 +41,8 @@ typedef struct {
 } WatermarkTextOptions;
 
 typedef struct {
+	int    Left;
+	int    Top;
 	int    Width;
 	int    DPI;
 	int    Margin;
@@ -411,7 +413,8 @@ vips_watermark(VipsImage *in, VipsImage **out, WatermarkTextOptions *to, Waterma
 			NULL) ||
 		vips_linear1(t[1], &t[2], o->Opacity, 0.0, NULL) ||
 		vips_cast(t[2], &t[3], VIPS_FORMAT_UCHAR, NULL) ||
-		vips_embed(t[3], &t[4], 100, 100, t[3]->Xsize + o->Margin, t[3]->Ysize + o->Margin, NULL)
+		vips_embed(t[3], &t[4], o->Left, o->Top, t[3]->Xsize + o->Margin + o->Left, t[3]->Ysize +
+		o->Margin +  o->Top, NULL)
 		) {
 		g_object_unref(base);
 		return 1;


### PR DESCRIPTION
When adding text to an image it is not possible to decide the position of the text.
For some reason the position of the text is hard-coded [here](https://github.com/h2non/bimg/blob/master/vips.h#L414) at 100px from top and 100px from left.

In this PR I added the Left and Top distance in the Watermark struct