### PR TITLE
Libvips documentation URL and README copy updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ bimg was designed to be a small and efficient library supporting a common set of
 
 bimg is able to output images as JPEG, PNG and WEBP formats, including transparent conversion across them.
 
-bimg uses internally libvips, a powerful library written in C for image processing which requires a [low memory footprint](http://www.vips.ecs.soton.ac.uk/index.php?title=Speed_and_Memory_Use)
+bimg uses internally libvips, a powerful library written in C for image processing which requires a [low memory footprint](https://github.com/jcupitt/libvips/wiki/Speed_and_Memory_Use)
 and it's typically 4x faster than using the quickest ImageMagick and GraphicsMagick settings or Go native `image` package, and in some cases it's even 8x faster processing JPEG images.
 
 If you're looking for an HTTP based image processing solution, see [imaginary](https://github.com/h2non/imaginary).
@@ -77,10 +77,10 @@ The [install script](https://github.com/h2non/bimg/blob/master/preinstall.sh) re
 
 ## Performance
 
-libvips is probably the faster open source solution for image processing.
+libvips is probably the fastest open source solution for image processing.
 Here you can see some performance test comparisons for multiple scenarios:
 
-- [libvips speed and memory usage](http://www.vips.ecs.soton.ac.uk/index.php?title=Speed_and_Memory_Use)
+- [libvips speed and memory usage](https://github.com/jcupitt/libvips/wiki/Speed-and-memory-use)
 
 ## Benchmark
 

--- a/image.go
+++ b/image.go
@@ -203,7 +203,7 @@ func (i *Image) Metadata() (ImageMetadata, error) {
 }
 
 // Interpretation gets the image interpretation type.
-// See: http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/VipsImage.html#VipsInterpretation
+// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 func (i *Image) Interpretation() (Interpretation, error) {
 	return ImageInterpretation(i.buffer)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -43,7 +43,7 @@ func ColourspaceIsSupported(buf []byte) (bool, error) {
 }
 
 // ImageInterpretation returns the image interpretation type.
-// See: http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/VipsImage.html#VipsInterpretation
+// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 func ImageInterpretation(buf []byte) (Interpretation, error) {
 	return vipsInterpretationBuffer(buf)
 }

--- a/options.go
+++ b/options.go
@@ -89,7 +89,7 @@ const (
 )
 
 // Interpretation represents the image interpretation type.
-// See: http://www.vips.ecs.soton.ac.uk/supported/current/doc/html/libvips/VipsImage.html#VipsInterpretation
+// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 type Interpretation int
 
 const (
@@ -119,7 +119,7 @@ const (
 
 // Extend represents the image extend mode, used when the edges
 // of an image are extended, you can specify how you want the extension done.
-// See: http://www.vips.ecs.soton.ac.uk/supported/8.4/doc/html/libvips/libvips-conversion.html#VIPS-EXTEND-BACKGROUND:CAPS
+// See: https://jcupitt.github.io/libvips/API/current/libvips-conversion.html#VIPS-EXTEND-BACKGROUND:CAPS
 type Extend int
 
 const (

--- a/vips.go
+++ b/vips.go
@@ -572,7 +572,7 @@ func vipsReduce(input *C.VipsImage, xshrink float64, yshrink float64) (*C.VipsIm
 func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, background Color) (*C.VipsImage, error) {
 	var image *C.VipsImage
 
-	// Max extend value, see: http://www.vips.ecs.soton.ac.uk/supported/8.4/doc/html/libvips/libvips-conversion.html#VipsExtend
+	// Max extend value, see: https://jcupitt.github.io/libvips/API/current/libvips-conversion.html#VipsExtend
 	if extend > 5 {
 		extend = ExtendBackground
 	}


### PR DESCRIPTION
Libvips' documentation has largely moved to Github. Update various links throughout `README.md` and code comments. 