### PR TITLE
Added extend option to affine

### DIFF
--- a/resizer.go
+++ b/resizer.go
@@ -216,7 +216,7 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 		if residualx < 1 && residualy < 1 {
 			image, err = vipsReduce(image, 1/residualx, 1/residualy)
 		} else {
-			image, err = vipsAffine(image, residualx, residualy, o.Interpolator)
+			image, err = vipsAffine(image, residualx, residualy, o.Interpolator, o.Extend, o.Background)
 		}
 		if err != nil {
 			return nil, err

--- a/vips.h
+++ b/vips.h
@@ -104,8 +104,13 @@ vips_enable_cache_set_trace() {
 }
 
 int
-vips_affine_interpolator(VipsImage *in, VipsImage **out, double a, double b, double c, double d, VipsInterpolate *interpolator) {
-	return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, NULL);
+vips_affine_interpolator(VipsImage *in, VipsImage **out, double a, double b, double c, double d, VipsInterpolate *interpolator, int extend, double red, double green, double blue) {
+	if (extend == VIPS_EXTEND_BACKGROUND) {
+		double background[3] = {red, green, blue};
+		VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+		return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, "extend", extend, "background", vipsBackground, NULL);
+	}
+	return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, "extend", extend, NULL);
 }
 
 int


### PR DESCRIPTION
Upscaling an image can leave a black bar on the right and bottom side. This is caused by rounding behaviour: depending on the resize ratio, the sampling convention (centre vs. corner) and the size of the original, you can get fractional pixels visible in the output image. It can be countered by using the extend option, but BIMG did not support this option for vipsAffine. This PR adds the functionality to vipsAffine in the same manner as vipsEmbed, which already uses it.

Example of an upscaled image with a black bar:

![69429871-d61e6c80-0d34-11ea-82c3-c95391402a31](https://user-images.githubusercontent.com/38294896/69531165-b1640800-0f73-11ea-883a-f6f95cb24190.jpg)

There is a different PR open for this issue right now (https://github.com/h2non/bimg/pull/307), but that one does not take the background color into account, which makes the ExtendBackground option unusable. This should fix that.
