### PR TITLE
Fix bug with images with alpha channel on embeding background

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -241,9 +241,14 @@ vips_zoom_bridge(VipsImage *in, VipsImage **out, int xfac, int yfac) {
 int
 vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b) {
 	if (extend == VIPS_EXTEND_BACKGROUND) {
+	if (has_alpha_channel(in) == 1) {
+		double background[4] = {r, g, b, 0.0};
+  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
+  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+	} else {
 		double background[3] = {r, g, b};
-		VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
-		return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);}
 	}
 	return vips_embed(in, out, left, top, width, height, "extend", extend, NULL);
 }


### PR DESCRIPTION
Adding background to images with alpha channel are failing with error `linear: vector must have 1 or 4 elements`.

Code, that reproduce the issue:
```
package main

import (
	"./bimg"
	"fmt"
	"io/ioutil"
	"log"
	"path"
)

func main() {
	files, err := ioutil.ReadDir("./images")
	if err != nil {
		log.Fatal(err)
	}

	for _, f := range files {
		data, err := ioutil.ReadFile(path.Join("./images", f.Name()))
		if err != nil {
			panic(err)
		}
		res, err := resize(data)
		if err != nil {
			panic(err)
			fmt.Printf("Image resize error: %s, file: %s\n", err, f.Name())
		}
		ioutil.WriteFile(path.Join("./res", f.Name()), res, 0644)
	}
}

func resize(data []byte) ([]byte, error) {
	image := bimg.NewImage(data)

	options := bimg.Options{
		Width:         300,
		Height:        300,
		Quality:       90,
		Interpolator:  bimg.Bicubic,
		StripMetadata: true,
		NoProfile:     true,
		Embed:         true,
		Type:          bimg.UNKNOWN,
		Crop:          false,
		Background:    bimg.Color{R: 255, G: 255, B: 255},
		Extend:        bimg.ExtendBackground,
	}
	return image.Process(options)
}
```
Image, that reproduce the issue: [https://gofile.io/?c=smyxFQ](https://gofile.io/?c=smyxFQ)