### PR TITLE
Reduce png size

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -305,7 +305,7 @@ vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compr
 		"strip", INT_TO_GBOOLEAN(strip),
 		"compression", compression,
 		"interlace", INT_TO_GBOOLEAN(interlace),
-		"filter", VIPS_FOREIGN_PNG_FILTER_NONE,
+		"filter", VIPS_FOREIGN_PNG_FILTER_ALL,
 		NULL
 	);
 #else


### PR DESCRIPTION
The vips_pngsave_bridge function uses the VIPS_FOREIGN_PNG_FILTER_NONE filter, which creates a 30% larger image. After switching to the VIPS_FOREIGN_PNG_FILTER_ALL filter, the file size is the same as for files created with another tool.

The default of the 'vipsthumbnail' utility is also the VIPS_FOREIGN_PNG_FILTER_ALL Filter.

Related issues: #221 and h2non/imaginary#237