### PR TITLE
Needs to update libvips documentation links

### DIFF
--- a/image.go
+++ b/image.go
@@ -209,7 +209,7 @@ func (i *Image) Metadata() (ImageMetadata, error) {
 }
 
 // Interpretation gets the image interpretation type.
-// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
+// See: https://libvips.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 func (i *Image) Interpretation() (Interpretation, error) {
 	return ImageInterpretation(i.buffer)
 }

--- a/metadata.go
+++ b/metadata.go
@@ -43,7 +43,7 @@ func ColourspaceIsSupported(buf []byte) (bool, error) {
 }
 
 // ImageInterpretation returns the image interpretation type.
-// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
+// See: https://libvips.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 func ImageInterpretation(buf []byte) (Interpretation, error) {
 	return vipsInterpretationBuffer(buf)
 }

--- a/options.go
+++ b/options.go
@@ -89,7 +89,7 @@ const (
 )
 
 // Interpretation represents the image interpretation type.
-// See: https://jcupitt.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
+// See: https://libvips.github.io/libvips/API/current/VipsImage.html#VipsInterpretation
 type Interpretation int
 
 const (
@@ -119,7 +119,7 @@ const (
 
 // Extend represents the image extend mode, used when the edges
 // of an image are extended, you can specify how you want the extension done.
-// See: https://jcupitt.github.io/libvips/API/current/libvips-conversion.html#VIPS-EXTEND-BACKGROUND:CAPS
+// See: https://libvips.github.io/libvips/API/current/libvips-conversion.html#VIPS-EXTEND-BACKGROUND:CAPS
 type Extend int
 
 const (

--- a/vips.go
+++ b/vips.go
@@ -580,7 +580,7 @@ func vipsReduce(input *C.VipsImage, xshrink float64, yshrink float64) (*C.VipsIm
 func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, background Color) (*C.VipsImage, error) {
 	var image *C.VipsImage
 
-	// Max extend value, see: https://jcupitt.github.io/libvips/API/current/libvips-conversion.html#VipsExtend
+	// Max extend value, see: https://libvips.github.io/libvips/API/current/libvips-conversion.html#VipsExtend
 	if extend > 5 {
 		extend = ExtendBackground
 	}


### PR DESCRIPTION
John Cupitt author of libvips moved repository to https://github.com/libvips/libvips. 
So links to the docs must be updated too.
Tnx