### PR TITLE
Support RGBA

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/h2non/bimg
+
+go 1.14

--- a/image_test.go
+++ b/image_test.go
@@ -224,7 +224,7 @@ func TestImageWatermark(t *testing.T) {
 		Opacity:    0.5,
 		Width:      200,
 		DPI:        100,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -282,7 +282,7 @@ func TestImageWatermarkNoReplicate(t *testing.T) {
 		Width:       200,
 		DPI:         100,
 		NoReplicate: true,
-		Background:  Color{255, 255, 255},
+		Background:  Color{255, 255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -394,7 +394,7 @@ func TestTransparentImageConvert(t *testing.T) {
 	image := initImage("transparent.png")
 	options := Options{
 		Type:       JPEG,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	}
 	buf, err := image.Process(options)
 	if err != nil {
@@ -541,7 +541,7 @@ func TestImageTrimParameters(t *testing.T) {
 	i := initImage("test.png")
 	options := Options{
 		Trim:       true,
-		Background: Color{0.0, 0.0, 0.0},
+		Background: Color{0, 0, 0, 255},
 		Threshold:  10.0,
 	}
 	buf, err := i.Process(options)
@@ -566,6 +566,60 @@ func TestImageLength(t *testing.T) {
 	if expected != actual {
 		t.Errorf("Size in Bytes of the image doesn't correspond. %d != %d", expected, actual)
 	}
+}
+
+func TestRGBAEmbed(t *testing.T) {
+	t.Run("transparent on background", func(t *testing.T) {
+		i := initImage("transparent.png")
+		buf, err := i.Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{255, 255, 255, 255},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/transparent_on_background_out.png", buf)
+	})
+
+	t.Run("transparent on transparent", func(t *testing.T) {
+		i := initImage("transparent.png")
+		buf, err := i.Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{0, 0, 0, 0},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/transparent_on_transparent_out.png", buf)
+	})
+
+	t.Run("opaque on transparent", func(t *testing.T) {
+		i := initImage("test.jpg")
+		buf, _ := i.Convert(PNG)
+		buf, err := NewImage(buf).Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{0, 0, 0, 0},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/opaque_on_transparent_out.png", buf)
+	})
 }
 
 func initImage(file string) *Image {

--- a/image_test.go
+++ b/image_test.go
@@ -583,6 +583,12 @@ func TestRGBAEmbed(t *testing.T) {
 			t.Errorf("The image could not be put on background: %v", err)
 		}
 
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if metadata.Alpha {
+			t.Errorf("Target image shouldn't have an alpha channel!")
+		}
+
 		Write("testdata/transparent_on_background_out.png", buf)
 	})
 
@@ -600,13 +606,26 @@ func TestRGBAEmbed(t *testing.T) {
 			t.Errorf("The image could not be put on background: %v", err)
 		}
 
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if !metadata.Alpha {
+			t.Errorf("Target image should have an alpha channel!")
+		}
+
 		Write("testdata/transparent_on_transparent_out.png", buf)
 	})
 
 	t.Run("opaque on transparent", func(t *testing.T) {
 		i := initImage("test.jpg")
-		buf, _ := i.Convert(PNG)
-		buf, err := NewImage(buf).Process(Options{
+
+		if metadata, err := i.Metadata(); err != nil {
+			t.Fatalf("Cannot read metadata from source image: %v", err)
+		} else if metadata.Alpha {
+			t.Fatalf("Source image should not have an alpha channel.")
+		}
+
+		buf, err := i.Process(Options{
+			Type: PNG,
 			Width: 500,
 			Height: 500,
 			Enlarge: true,
@@ -616,6 +635,12 @@ func TestRGBAEmbed(t *testing.T) {
 		})
 		if err != nil {
 			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if !metadata.Alpha {
+			t.Errorf("Target image should have an alpha channel!")
 		}
 
 		Write("testdata/opaque_on_transparent_out.png", buf)

--- a/options.go
+++ b/options.go
@@ -142,13 +142,15 @@ const (
 // WatermarkFont defines the default watermark font to be used.
 var WatermarkFont = "sans 10"
 
-// Color represents a traditional RGB color scheme.
+// Color represents a traditional RGBA color scheme.
 type Color struct {
-	R, G, B uint8
+	R, G, B, A uint8
 }
 
 // ColorBlack is a shortcut to black RGB color representation.
-var ColorBlack = Color{0, 0, 0}
+var ColorBlack = Color{0x00, 0x00, 0x00, 0xFF}
+// ColorWhite is a shortcut to white RGB color representation.
+var ColorWhite = Color{0xFF, 0xFF, 0xFF, 0xFF}
 
 // Watermark represents the text-based watermark supported options.
 type Watermark struct {

--- a/resizer.go
+++ b/resizer.go
@@ -403,7 +403,9 @@ func watermarkImageWithAnotherImage(image *C.VipsImage, w WatermarkImage) (*C.Vi
 }
 
 func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsImage, error) {
-	if o.Background == ColorBlack {
+	// If no alpha channel is set, there is nothing to flatten. We basically assume that the
+	// background stays untouched.
+	if o.Background.A == 0 {
 		return image, nil
 	}
 	return vipsFlattenBackground(image, o.Background)

--- a/resizer.go
+++ b/resizer.go
@@ -403,9 +403,9 @@ func watermarkImageWithAnotherImage(image *C.VipsImage, w WatermarkImage) (*C.Vi
 }
 
 func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsImage, error) {
-	// If no alpha channel is set, there is nothing to flatten. We basically assume that the
-	// background stays untouched.
-	if o.Background.A == 0 {
+	// If the background is not opaque (alpha channel maxed), we should not flatten, as this
+	// would remove the alpha channel.
+	if o.Background.A < 0xFF {
 		return image, nil
 	}
 	return vipsFlattenBackground(image, o.Background)

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -263,7 +263,7 @@ func TestNoColorProfile(t *testing.T) {
 }
 
 func TestEmbedExtendColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10, 255}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -280,7 +280,7 @@ func TestEmbedExtendColor(t *testing.T) {
 }
 
 func TestEmbedExtendWithCustomColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10, 255}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -790,7 +790,7 @@ func BenchmarkWatermarkJpeg(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.jpg", options, b)
@@ -805,7 +805,7 @@ func BenchmarkWatermarkPng(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.png", options, b)
@@ -820,7 +820,7 @@ func BenchmarkWatermarkWebp(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.webp", options, b)

--- a/vips.go
+++ b/vips.go
@@ -649,7 +649,7 @@ func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, 
 
 	defer C.g_object_unref(C.gpointer(input))
 	err := C.vips_embed_bridge(input, &image, C.int(left), C.int(top), C.int(width),
-		C.int(height), C.int(extend), C.double(background.R), C.double(background.G), C.double(background.B))
+		C.int(height), C.int(extend), C.double(background.R), C.double(background.G), C.double(background.B), C.double(background.A))
 	if err != 0 {
 		return nil, catchVipsError()
 	}

--- a/vips.h
+++ b/vips.h
@@ -269,16 +269,30 @@ vips_zoom_bridge(VipsImage *in, VipsImage **out, int xfac, int yfac) {
 }
 
 int
-vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b) {
+vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b, double a) {
 	if (extend == VIPS_EXTEND_BACKGROUND) {
-	if (has_alpha_channel(in) == 1) {
-		double background[4] = {r, g, b, 0.0};
-  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
-  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
-	} else {
-		double background[3] = {r, g, b};
-  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
-  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);}
+		int hasAlpha = has_alpha_channel(in);
+		
+		// We don't have an alpha channel but request alpha to be present? Add a channel then.
+		if (hasAlpha == 0 && a < 255.0) {
+			VipsImage *withAlpha = vips_image_new();
+			vips_addalpha(in, &withAlpha);
+			double background[4] = {r, g, b, a};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
+			int result = vips_embed(withAlpha, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+			g_object_unref(withAlpha);
+			return result;
+		}
+
+		if (hasAlpha == 1) {
+			double background[4] = {r, g, b, a};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
+			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+		} else {
+			double background[3] = {r, g, b};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+		}
 	}
 	return vips_embed(in, out, left, top, width, height, "extend", extend, NULL);
 }
@@ -335,7 +349,7 @@ vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compr
 		"compression", compression,
 		"interlace", INT_TO_GBOOLEAN(interlace),
 		"filter", VIPS_FOREIGN_PNG_FILTER_ALL,
-	        "palette", INT_TO_GBOOLEAN(palette),
+		"palette", INT_TO_GBOOLEAN(palette),
 		NULL
 	);
 #else

--- a/vips_test.go
+++ b/vips_test.go
@@ -147,7 +147,7 @@ func TestVipsWatermark(t *testing.T) {
 		Width:      200,
 		DPI:        100,
 		Margin:     100,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	}
 
 	newImg, err := vipsWatermark(image, watermark)


### PR DESCRIPTION
This PR is a shot at implementing #332.

* Colors are now RGBA.
* Embedding now considers adding an alpha channel if necessary.
* Flattening is now only performed if the background color does not have an alpha channel set (`A > 0`).
* Added `go.mod` (makes it easier to use in "modern" Go projects :-))

The biggest downside of this change is, that it "breaks" the API by changing the `Color` struct. I deemed this better than the alternatives, though:

* Adding a separate struct that supports alpha would mean two `Options` attributes - one with and one without alpha.
  
  This means, that it is now harder to communicate which one has precedence and it is also harder to check in code (is the default = empty struct black, or unset?).

  Positive side effect: if now someone actually wants black, s/he has to set the struct to an actual value with an actual alpha channel (otherwise it would stay transparent/unchanged).

  The change itself is only a small piece (not many places use colors) so it is better that the compiler now warns about the changed interface than introducing it silently. Now it can be properly reviewed how the alpha channel should be dealt with.

* Using an interface (like `color.Color` in the stdlib) would be a nice way as well, however the perfect name for that interface would be ... `Color`. So it would also collide with the current struct.

  The naming would then be something like `RGB`, `RGBA` (structs) and `Color` (interface).

  An upside would be, that using an interface in the `Options` would default to `nil`. That way we would definitely know if a background color has been set or not. A downside obviously is, that it can be `nil`.... probably a matter of taste. And of course it also breaks the API compatibility. Just differently.

* Using interfaces, but keep `Color` a struct and find a nice name for the other struct (`ColorA`?) and the interface (`RGBA`? `Colorer`? ;-))

  That would most likely keep most of the code compatible (since the `bimg.Color` would fulfill the interface) but the names are then no really optimal. And there is also still the `nil` thing which can be either good or bad.

Feel free to suggest improvements.

I am happy to hear your stance on the `Color` change and what you would prefer as well.