### PR TITLE
Restructure transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,25 +275,45 @@ bimg.Write("new.jpg", newImage)
 
 #### Fluent interface
 
+If you intend to apply multiple transformations to the same image, you
+should use the `ImageTransformation` system which will decode the image
+once and lets you work on this decoded image as long as you please.
+
 ```go
+// read the raw data
 buffer, err := bimg.Read("image.jpg")
 if err != nil {
   fmt.Fprintln(os.Stderr, err)
+  return
 }
 
-image := bimg.NewImage(buffer)
-
-// first crop image
-_, err := image.CropByWidth(300)
+// decode the image and prepare our transformation chain
+it, err := bimg.NewImageTransformation(buffer)
 if err != nil {
   fmt.Fprintln(os.Stderr, err)
+  return
+}
+
+// crop the image to a specific width
+err = it.Crop(bimg.CropOptions{Width: 300})
+if err != nil {
+  fmt.Fprintln(os.Stderr, err)
+  return
 }
 
 // then flip it
-newImage, err := image.Flip()
+err = it.Rotate(bimg.RotateOptions{Flip: true})
 if err != nil {
   fmt.Fprintln(os.Stderr, err)
+  return
 }
+
+// encode the image
+newImage, err := it.Save(bimg.SaveOptions{})
+if err != nil {
+  fmt.Fprintln(os.Stderr, err)
+  return
+} 
 
 // save the cropped and flipped image
 bimg.Write("new.jpg", newImage)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/h2non/bimg
+
+go 1.14

--- a/image_test.go
+++ b/image_test.go
@@ -352,8 +352,8 @@ func TestImageAutoRotate(t *testing.T) {
 	}
 
 	tests := []struct {
-		file         string
-		orientation  int
+		file        string
+		orientation int
 	}{
 		{"exif/Landscape_1.jpg", 1},
 		{"exif/Landscape_2.jpg", 1},
@@ -365,20 +365,22 @@ func TestImageAutoRotate(t *testing.T) {
 	}
 
 	for index, test := range tests {
-		img := initImage(test.file)
-		buf, err := img.AutoRotate()
-		if err != nil {
-			t.Errorf("Cannot process the image: %#v", err)
-		}
-		Write(fmt.Sprintf("testdata/test_autorotate_%d_out.jpg", index), buf)
+		t.Run(test.file, func(t *testing.T) {
+			img := initImage(test.file)
+			buf, err := img.AutoRotate()
+			if err != nil {
+				t.Errorf("Cannot process the image: %#v", err)
+			}
+			Write(fmt.Sprintf("testdata/test_autorotate_%d_out.jpg", index), buf)
 
-		meta, err := img.Metadata()
-		if err != nil {
-			t.Errorf("Cannot read image metadata: %#v", err)
-		}
-		if meta.Orientation != test.orientation {
-			t.Errorf("Invalid image orientation for %s: %d != %d", test.file, meta.Orientation, test.orientation)
-		}
+			meta, err := img.Metadata()
+			if err != nil {
+				t.Errorf("Cannot read image metadata: %#v", err)
+			}
+			if meta.Orientation != test.orientation {
+				t.Errorf("Invalid image orientation for %s: %d != %d", test.file, meta.Orientation, test.orientation)
+			}
+		})
 	}
 }
 
@@ -572,11 +574,11 @@ func TestRGBAEmbed(t *testing.T) {
 	t.Run("transparent on background", func(t *testing.T) {
 		i := initImage("transparent.png")
 		buf, err := i.Process(Options{
-			Width: 500,
-			Height: 500,
-			Enlarge: true,
-			Embed: true,
-			Extend: ExtendBackground,
+			Width:      500,
+			Height:     500,
+			Enlarge:    true,
+			Embed:      true,
+			Extend:     ExtendBackground,
 			Background: ColorWithAlpha{Color{255, 255, 255}, 255},
 		})
 		if err != nil {
@@ -595,11 +597,11 @@ func TestRGBAEmbed(t *testing.T) {
 	t.Run("transparent on transparent", func(t *testing.T) {
 		i := initImage("transparent.png")
 		buf, err := i.Process(Options{
-			Width: 500,
-			Height: 500,
-			Enlarge: true,
-			Embed: true,
-			Extend: ExtendBackground,
+			Width:      500,
+			Height:     500,
+			Enlarge:    true,
+			Embed:      true,
+			Extend:     ExtendBackground,
 			Background: ColorWithAlpha{Color{0, 0, 0}, 0},
 		})
 		if err != nil {
@@ -625,12 +627,12 @@ func TestRGBAEmbed(t *testing.T) {
 		}
 
 		buf, err := i.Process(Options{
-			Type: PNG,
-			Width: 500,
-			Height: 500,
-			Enlarge: true,
-			Embed: true,
-			Extend: ExtendBackground,
+			Type:       PNG,
+			Width:      500,
+			Height:     500,
+			Enlarge:    true,
+			Embed:      true,
+			Extend:     ExtendBackground,
 			Background: ColorWithAlpha{Color{0, 0, 0}, 0},
 		})
 		if err != nil {

--- a/image_test.go
+++ b/image_test.go
@@ -224,7 +224,7 @@ func TestImageWatermark(t *testing.T) {
 		Opacity:    0.5,
 		Width:      200,
 		DPI:        100,
-		Background: Color{255, 255, 255, 255},
+		Background: Color{255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -282,7 +282,7 @@ func TestImageWatermarkNoReplicate(t *testing.T) {
 		Width:       200,
 		DPI:         100,
 		NoReplicate: true,
-		Background:  Color{255, 255, 255, 255},
+		Background:  Color{255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -394,7 +394,7 @@ func TestTransparentImageConvert(t *testing.T) {
 	image := initImage("transparent.png")
 	options := Options{
 		Type:       JPEG,
-		Background: Color{255, 255, 255, 255},
+		Background: Color{255, 255, 255},
 	}
 	buf, err := image.Process(options)
 	if err != nil {
@@ -541,7 +541,7 @@ func TestImageTrimParameters(t *testing.T) {
 	i := initImage("test.png")
 	options := Options{
 		Trim:       true,
-		Background: Color{0, 0, 0, 255},
+		Background: Color{0, 0, 0},
 		Threshold:  10.0,
 	}
 	buf, err := i.Process(options)
@@ -577,7 +577,7 @@ func TestRGBAEmbed(t *testing.T) {
 			Enlarge: true,
 			Embed: true,
 			Extend: ExtendBackground,
-			Background: Color{255, 255, 255, 255},
+			Background: ColorWithAlpha{Color{255, 255, 255}, 255},
 		})
 		if err != nil {
 			t.Errorf("The image could not be put on background: %v", err)
@@ -600,7 +600,7 @@ func TestRGBAEmbed(t *testing.T) {
 			Enlarge: true,
 			Embed: true,
 			Extend: ExtendBackground,
-			Background: Color{0, 0, 0, 0},
+			Background: ColorWithAlpha{Color{0, 0, 0}, 0},
 		})
 		if err != nil {
 			t.Errorf("The image could not be put on background: %v", err)
@@ -631,7 +631,7 @@ func TestRGBAEmbed(t *testing.T) {
 			Enlarge: true,
 			Embed: true,
 			Extend: ExtendBackground,
-			Background: Color{0, 0, 0, 0},
+			Background: ColorWithAlpha{Color{0, 0, 0}, 0},
 		})
 		if err != nil {
 			t.Errorf("The image could not be put on background: %v", err)

--- a/image_test.go
+++ b/image_test.go
@@ -42,7 +42,7 @@ func TestImageSvgResize(t *testing.T) {
 }
 
 func TestImageGifToJpeg(t *testing.T) {
-	if VipsMajorVersion >= 8 && VipsMinorVersion > 2 {
+	if vipsVersionMin(8, 3) {
 		i := initImage("test.gif")
 		options := Options{
 			Type: JPEG,
@@ -57,7 +57,7 @@ func TestImageGifToJpeg(t *testing.T) {
 }
 
 func TestImagePdfToJpeg(t *testing.T) {
-	if VipsMajorVersion >= 8 && VipsMinorVersion > 2 {
+	if vipsVersionMin(8, 3) {
 		i := initImage("test.pdf")
 		options := Options{
 			Type: JPEG,
@@ -72,7 +72,7 @@ func TestImagePdfToJpeg(t *testing.T) {
 }
 
 func TestImageSvgToJpeg(t *testing.T) {
-	if VipsMajorVersion >= 8 && VipsMinorVersion > 2 {
+	if vipsVersionMin(8, 3) {
 		i := initImage("test.svg")
 		options := Options{
 			Type: JPEG,
@@ -346,7 +346,7 @@ func TestImageRotate(t *testing.T) {
 }
 
 func TestImageAutoRotate(t *testing.T) {
-	if VipsMajorVersion <= 8 && VipsMinorVersion < 10 {
+	if !vipsVersionMin(8, 10) {
 		t.Skip("Skip test in libvips < 8.10")
 		return
 	}
@@ -496,7 +496,7 @@ func TestFluentInterface(t *testing.T) {
 
 func TestImageSmartCrop(t *testing.T) {
 
-	if !(VipsMajorVersion >= 8 && VipsMinorVersion >= 5) {
+	if !(vipsVersionMin(8, 5)) {
 		t.Skipf("Skipping this test, libvips doesn't meet version requirement %s >= 8.5", VipsVersion)
 	}
 
@@ -516,7 +516,7 @@ func TestImageSmartCrop(t *testing.T) {
 
 func TestImageTrim(t *testing.T) {
 
-	if !(VipsMajorVersion >= 8 && VipsMinorVersion >= 6) {
+	if !vipsVersionMin(8, 6) {
 		t.Skipf("Skipping this test, libvips doesn't meet version requirement %s >= 8.6", VipsVersion)
 	}
 
@@ -536,7 +536,7 @@ func TestImageTrim(t *testing.T) {
 
 func TestImageTrimParameters(t *testing.T) {
 
-	if !(VipsMajorVersion >= 8 && VipsMinorVersion >= 6) {
+	if !vipsVersionMin(8, 6) {
 		t.Skipf("Skipping this test, libvips doesn't meet version requirement %s >= 8.6", VipsVersion)
 	}
 

--- a/image_test.go
+++ b/image_test.go
@@ -21,10 +21,18 @@ func TestImageResize(t *testing.T) {
 }
 
 func TestImageGifResize(t *testing.T) {
-	_, err := initImage("test.gif").Resize(300, 240)
-	if err == nil {
-		t.Errorf("GIF shouldn't be saved within VIPS")
+	buf, err := initImage("test.gif").Resize(300, 240)
+	if err != nil {
+		t.Errorf("Cannot process the image: %#v", err)
+		return
 	}
+
+	err = assertSize(buf, 300, 240)
+	if err != nil {
+		t.Error(err)
+	}
+
+	Write("testdata/test_resize_out.gif", buf)
 }
 
 func TestImagePdfResize(t *testing.T) {

--- a/image_test.go
+++ b/image_test.go
@@ -224,7 +224,7 @@ func TestImageWatermark(t *testing.T) {
 		Opacity:    0.5,
 		Width:      200,
 		DPI:        100,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -282,7 +282,7 @@ func TestImageWatermarkNoReplicate(t *testing.T) {
 		Width:       200,
 		DPI:         100,
 		NoReplicate: true,
-		Background:  Color{255, 255, 255},
+		Background:  Color{255, 255, 255, 255},
 	})
 	if err != nil {
 		t.Error(err)
@@ -394,7 +394,7 @@ func TestTransparentImageConvert(t *testing.T) {
 	image := initImage("transparent.png")
 	options := Options{
 		Type:       JPEG,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	}
 	buf, err := image.Process(options)
 	if err != nil {
@@ -541,7 +541,7 @@ func TestImageTrimParameters(t *testing.T) {
 	i := initImage("test.png")
 	options := Options{
 		Trim:       true,
-		Background: Color{0.0, 0.0, 0.0},
+		Background: Color{0, 0, 0, 255},
 		Threshold:  10.0,
 	}
 	buf, err := i.Process(options)
@@ -566,6 +566,60 @@ func TestImageLength(t *testing.T) {
 	if expected != actual {
 		t.Errorf("Size in Bytes of the image doesn't correspond. %d != %d", expected, actual)
 	}
+}
+
+func TestRGBAEmbed(t *testing.T) {
+	t.Run("transparent on background", func(t *testing.T) {
+		i := initImage("transparent.png")
+		buf, err := i.Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{255, 255, 255, 255},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/transparent_on_background_out.png", buf)
+	})
+
+	t.Run("transparent on transparent", func(t *testing.T) {
+		i := initImage("transparent.png")
+		buf, err := i.Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{0, 0, 0, 0},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/transparent_on_transparent_out.png", buf)
+	})
+
+	t.Run("opaque on transparent", func(t *testing.T) {
+		i := initImage("test.jpg")
+		buf, _ := i.Convert(PNG)
+		buf, err := NewImage(buf).Process(Options{
+			Width: 500,
+			Height: 500,
+			Enlarge: true,
+			Embed: true,
+			Extend: ExtendBackground,
+			Background: Color{0, 0, 0, 0},
+		})
+		if err != nil {
+			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		Write("testdata/opaque_on_transparent_out.png", buf)
+	})
 }
 
 func initImage(file string) *Image {

--- a/image_test.go
+++ b/image_test.go
@@ -583,6 +583,12 @@ func TestRGBAEmbed(t *testing.T) {
 			t.Errorf("The image could not be put on background: %v", err)
 		}
 
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if metadata.Alpha {
+			t.Errorf("Target image shouldn't have an alpha channel!")
+		}
+
 		Write("testdata/transparent_on_background_out.png", buf)
 	})
 
@@ -600,13 +606,26 @@ func TestRGBAEmbed(t *testing.T) {
 			t.Errorf("The image could not be put on background: %v", err)
 		}
 
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if !metadata.Alpha {
+			t.Errorf("Target image should have an alpha channel!")
+		}
+
 		Write("testdata/transparent_on_transparent_out.png", buf)
 	})
 
 	t.Run("opaque on transparent", func(t *testing.T) {
 		i := initImage("test.jpg")
-		buf, _ := i.Convert(PNG)
-		buf, err := NewImage(buf).Process(Options{
+
+		if metadata, err := i.Metadata(); err != nil {
+			t.Fatalf("Cannot read metadata from source image: %v", err)
+		} else if metadata.Alpha {
+			t.Fatalf("Source image should not have an alpha channel.")
+		}
+
+		buf, err := i.Process(Options{
+			Type: PNG,
 			Width: 500,
 			Height: 500,
 			Enlarge: true,
@@ -616,6 +635,12 @@ func TestRGBAEmbed(t *testing.T) {
 		})
 		if err != nil {
 			t.Errorf("The image could not be put on background: %v", err)
+		}
+
+		if metadata, err := i.Metadata(); err != nil {
+			t.Errorf("Cannot read metadata from target image: %v", err)
+		} else if !metadata.Alpha {
+			t.Errorf("Target image should have an alpha channel!")
 		}
 
 		Write("testdata/opaque_on_transparent_out.png", buf)

--- a/metadata.go
+++ b/metadata.go
@@ -137,15 +137,14 @@ type EXIF struct {
 
 // Size returns the image size by width and height pixels.
 func Size(buf []byte) (ImageSize, error) {
-	metadata, err := Metadata(buf)
+	defer C.vips_thread_shutdown()
+
+	t, err := NewImageTransformation(buf)
 	if err != nil {
 		return ImageSize{}, err
 	}
-
-	return ImageSize{
-		Width:  int(metadata.Size.Width),
-		Height: int(metadata.Size.Height),
-	}, nil
+	defer t.Close()
+	return t.Size(), nil
 }
 
 // ColourspaceIsSupported checks if the image colourspace is supported by libvips.
@@ -163,81 +162,10 @@ func ImageInterpretation(buf []byte) (Interpretation, error) {
 func Metadata(buf []byte) (ImageMetadata, error) {
 	defer C.vips_thread_shutdown()
 
-	image, imageType, err := vipsRead(buf)
+	t, err := NewImageTransformation(buf)
 	if err != nil {
 		return ImageMetadata{}, err
 	}
-	defer C.g_object_unref(C.gpointer(image))
-
-	size := ImageSize{
-		Width:  int(image.c.Xsize),
-		Height: int(image.c.Ysize),
-	}
-
-	orientation := vipsExifIntTag(image, Orientation)
-
-	metadata := ImageMetadata{
-		Size:        size,
-		Channels:    int(image.c.Bands),
-		Orientation: orientation,
-		Alpha:       vipsHasAlpha(image),
-		Profile:     vipsHasProfile(image),
-		Space:       vipsSpace(image),
-		Type:        ImageTypeName(imageType),
-		EXIF: EXIF{
-			Make:                    vipsExifStringTag(image, Make),
-			Model:                   vipsExifStringTag(image, Model),
-			Orientation:             orientation,
-			XResolution:             vipsExifStringTag(image, XResolution),
-			YResolution:             vipsExifStringTag(image, YResolution),
-			ResolutionUnit:          vipsExifIntTag(image, ResolutionUnit),
-			Software:                vipsExifStringTag(image, Software),
-			Datetime:                vipsExifStringTag(image, Datetime),
-			YCbCrPositioning:        vipsExifIntTag(image, YCbCrPositioning),
-			Compression:             vipsExifIntTag(image, Compression),
-			ExposureTime:            vipsExifStringTag(image, ExposureTime),
-			FNumber:                 vipsExifStringTag(image, FNumber),
-			ExposureProgram:         vipsExifIntTag(image, ExposureProgram),
-			ISOSpeedRatings:         vipsExifIntTag(image, ISOSpeedRatings),
-			ExifVersion:             vipsExifStringTag(image, ExifVersion),
-			DateTimeOriginal:        vipsExifStringTag(image, DateTimeOriginal),
-			DateTimeDigitized:       vipsExifStringTag(image, DateTimeDigitized),
-			ComponentsConfiguration: vipsExifStringTag(image, ComponentsConfiguration),
-			ShutterSpeedValue:       vipsExifStringTag(image, ShutterSpeedValue),
-			ApertureValue:           vipsExifStringTag(image, ApertureValue),
-			BrightnessValue:         vipsExifStringTag(image, BrightnessValue),
-			ExposureBiasValue:       vipsExifStringTag(image, ExposureBiasValue),
-			MeteringMode:            vipsExifIntTag(image, MeteringMode),
-			Flash:                   vipsExifIntTag(image, Flash),
-			FocalLength:             vipsExifStringTag(image, FocalLength),
-			SubjectArea:             vipsExifStringTag(image, SubjectArea),
-			MakerNote:               vipsExifStringTag(image, MakerNote),
-			SubSecTimeOriginal:      vipsExifStringTag(image, SubSecTimeOriginal),
-			SubSecTimeDigitized:     vipsExifStringTag(image, SubSecTimeDigitized),
-			ColorSpace:              vipsExifIntTag(image, ColorSpace),
-			PixelXDimension:         vipsExifIntTag(image, PixelXDimension),
-			PixelYDimension:         vipsExifIntTag(image, PixelYDimension),
-			SensingMethod:           vipsExifIntTag(image, SensingMethod),
-			SceneType:               vipsExifStringTag(image, SceneType),
-			ExposureMode:            vipsExifIntTag(image, ExposureMode),
-			WhiteBalance:            vipsExifIntTag(image, WhiteBalance),
-			FocalLengthIn35mmFilm:   vipsExifIntTag(image, FocalLengthIn35mmFilm),
-			SceneCaptureType:        vipsExifIntTag(image, SceneCaptureType),
-			GPSLatitudeRef:          vipsExifStringTag(image, GPSLatitudeRef),
-			GPSLatitude:             vipsExifStringTag(image, GPSLatitude),
-			GPSLongitudeRef:         vipsExifStringTag(image, GPSLongitudeRef),
-			GPSLongitude:            vipsExifStringTag(image, GPSLongitude),
-			GPSAltitudeRef:          vipsExifStringTag(image, GPSAltitudeRef),
-			GPSAltitude:             vipsExifStringTag(image, GPSAltitude),
-			GPSSpeedRef:             vipsExifStringTag(image, GPSSpeedRef),
-			GPSSpeed:                vipsExifStringTag(image, GPSSpeed),
-			GPSImgDirectionRef:      vipsExifStringTag(image, GPSImgDirectionRef),
-			GPSImgDirection:         vipsExifStringTag(image, GPSImgDirection),
-			GPSDestBearingRef:       vipsExifStringTag(image, GPSDestBearingRef),
-			GPSDestBearing:          vipsExifStringTag(image, GPSDestBearing),
-			GPSDateStamp:            vipsExifStringTag(image, GPSDateStamp),
-		},
-	}
-
-	return metadata, nil
+	defer t.Close()
+	return t.Metadata(), nil
 }

--- a/metadata.go
+++ b/metadata.go
@@ -8,57 +8,57 @@ import "C"
 
 // Common EXIF fields for data extraction
 const (
-	Make = "exif-ifd0-Make"
-	Model = "exif-ifd0-Model"
-	Orientation = "exif-ifd0-Orientation"
-	XResolution = "exif-ifd0-XResolution"
-	YResolution = "exif-ifd0-YResolution"
-	ResolutionUnit = "exif-ifd0-ResolutionUnit"
-	Software = "exif-ifd0-Software"
-	Datetime = "exif-ifd0-DateTime"
-	YCbCrPositioning = "exif-ifd0-YCbCrPositioning"
-	Compression = "exif-ifd1-Compression"
-	ExposureTime = "exif-ifd2-ExposureTime"
-	FNumber = "exif-ifd2-FNumber"
-	ExposureProgram = "exif-ifd2-ExposureProgram"
-	ISOSpeedRatings = "exif-ifd2-ISOSpeedRatings"
-	ExifVersion = "exif-ifd2-ExifVersion"
-	DateTimeOriginal = "exif-ifd2-DateTimeOriginal"
-	DateTimeDigitized = "exif-ifd2-DateTimeDigitized"
+	Make                    = "exif-ifd0-Make"
+	Model                   = "exif-ifd0-Model"
+	Orientation             = "exif-ifd0-Orientation"
+	XResolution             = "exif-ifd0-XResolution"
+	YResolution             = "exif-ifd0-YResolution"
+	ResolutionUnit          = "exif-ifd0-ResolutionUnit"
+	Software                = "exif-ifd0-Software"
+	Datetime                = "exif-ifd0-DateTime"
+	YCbCrPositioning        = "exif-ifd0-YCbCrPositioning"
+	Compression             = "exif-ifd1-Compression"
+	ExposureTime            = "exif-ifd2-ExposureTime"
+	FNumber                 = "exif-ifd2-FNumber"
+	ExposureProgram         = "exif-ifd2-ExposureProgram"
+	ISOSpeedRatings         = "exif-ifd2-ISOSpeedRatings"
+	ExifVersion             = "exif-ifd2-ExifVersion"
+	DateTimeOriginal        = "exif-ifd2-DateTimeOriginal"
+	DateTimeDigitized       = "exif-ifd2-DateTimeDigitized"
 	ComponentsConfiguration = "exif-ifd2-ComponentsConfiguration"
-	ShutterSpeedValue = "exif-ifd2-ShutterSpeedValue"
-	ApertureValue = "exif-ifd2-ApertureValue"
-	BrightnessValue = "exif-ifd2-BrightnessValue"
-	ExposureBiasValue = "exif-ifd2-ExposureBiasValue"
-	MeteringMode = "exif-ifd2-MeteringMode"
-	Flash = "exif-ifd2-Flash"
-	FocalLength = "exif-ifd2-FocalLength"
-	SubjectArea = "exif-ifd2-SubjectArea"
-	MakerNote = "exif-ifd2-MakerNote"
-	SubSecTimeOriginal = "exif-ifd2-SubSecTimeOriginal"
-	SubSecTimeDigitized = "exif-ifd2-SubSecTimeDigitized"
-	ColorSpace = "exif-ifd2-ColorSpace"
-	PixelXDimension = "exif-ifd2-PixelXDimension"
-	PixelYDimension = "exif-ifd2-PixelYDimension"
-	SensingMethod = "exif-ifd2-SensingMethod"
-	SceneType = "exif-ifd2-SceneType"
-	ExposureMode = "exif-ifd2-ExposureMode"
-	WhiteBalance = "exif-ifd2-WhiteBalance"
-	FocalLengthIn35mmFilm = "exif-ifd2-FocalLengthIn35mmFilm"
-	SceneCaptureType = "exif-ifd2-SceneCaptureType"
-	GPSLatitudeRef = "exif-ifd3-GPSLatitudeRef"
-	GPSLatitude = "exif-ifd3-GPSLatitude"
-	GPSLongitudeRef = "exif-ifd3-GPSLongitudeRef"
-	GPSLongitude = "exif-ifd3-GPSLongitude"
-	GPSAltitudeRef = "exif-ifd3-GPSAltitudeRef"
-	GPSAltitude = "exif-ifd3-GPSAltitude"
-	GPSSpeedRef = "exif-ifd3-GPSSpeedRef"
-	GPSSpeed = "exif-ifd3-GPSSpeed"
-	GPSImgDirectionRef = "exif-ifd3-GPSImgDirectionRef"
-	GPSImgDirection = "exif-ifd3-GPSImgDirection"
-	GPSDestBearingRef = "exif-ifd3-GPSDestBearingRef"
-	GPSDestBearing = "exif-ifd3-GPSDestBearing"
-	GPSDateStamp = "exif-ifd3-GPSDateStamp"
+	ShutterSpeedValue       = "exif-ifd2-ShutterSpeedValue"
+	ApertureValue           = "exif-ifd2-ApertureValue"
+	BrightnessValue         = "exif-ifd2-BrightnessValue"
+	ExposureBiasValue       = "exif-ifd2-ExposureBiasValue"
+	MeteringMode            = "exif-ifd2-MeteringMode"
+	Flash                   = "exif-ifd2-Flash"
+	FocalLength             = "exif-ifd2-FocalLength"
+	SubjectArea             = "exif-ifd2-SubjectArea"
+	MakerNote               = "exif-ifd2-MakerNote"
+	SubSecTimeOriginal      = "exif-ifd2-SubSecTimeOriginal"
+	SubSecTimeDigitized     = "exif-ifd2-SubSecTimeDigitized"
+	ColorSpace              = "exif-ifd2-ColorSpace"
+	PixelXDimension         = "exif-ifd2-PixelXDimension"
+	PixelYDimension         = "exif-ifd2-PixelYDimension"
+	SensingMethod           = "exif-ifd2-SensingMethod"
+	SceneType               = "exif-ifd2-SceneType"
+	ExposureMode            = "exif-ifd2-ExposureMode"
+	WhiteBalance            = "exif-ifd2-WhiteBalance"
+	FocalLengthIn35mmFilm   = "exif-ifd2-FocalLengthIn35mmFilm"
+	SceneCaptureType        = "exif-ifd2-SceneCaptureType"
+	GPSLatitudeRef          = "exif-ifd3-GPSLatitudeRef"
+	GPSLatitude             = "exif-ifd3-GPSLatitude"
+	GPSLongitudeRef         = "exif-ifd3-GPSLongitudeRef"
+	GPSLongitude            = "exif-ifd3-GPSLongitude"
+	GPSAltitudeRef          = "exif-ifd3-GPSAltitudeRef"
+	GPSAltitude             = "exif-ifd3-GPSAltitude"
+	GPSSpeedRef             = "exif-ifd3-GPSSpeedRef"
+	GPSSpeed                = "exif-ifd3-GPSSpeed"
+	GPSImgDirectionRef      = "exif-ifd3-GPSImgDirectionRef"
+	GPSImgDirection         = "exif-ifd3-GPSImgDirection"
+	GPSDestBearingRef       = "exif-ifd3-GPSDestBearingRef"
+	GPSDestBearing          = "exif-ifd3-GPSDestBearing"
+	GPSDateStamp            = "exif-ifd3-GPSDateStamp"
 )
 
 // ImageSize represents the image width and height values
@@ -77,62 +77,62 @@ type ImageMetadata struct {
 	Space       string
 	Colourspace string
 	Size        ImageSize
-	EXIF EXIF
+	EXIF        EXIF
 }
 
 // EXIF image metadata
 type EXIF struct {
-	Make string
-	Model string
-	Orientation int
-	XResolution string
-	YResolution string
-	ResolutionUnit int
-	Software string
-	Datetime string
-	YCbCrPositioning int
-	Compression int
-	ExposureTime string
-	FNumber string
-	ExposureProgram int
-	ISOSpeedRatings int
-	ExifVersion string
-	DateTimeOriginal string
-	DateTimeDigitized string
+	Make                    string
+	Model                   string
+	Orientation             int
+	XResolution             string
+	YResolution             string
+	ResolutionUnit          int
+	Software                string
+	Datetime                string
+	YCbCrPositioning        int
+	Compression             int
+	ExposureTime            string
+	FNumber                 string
+	ExposureProgram         int
+	ISOSpeedRatings         int
+	ExifVersion             string
+	DateTimeOriginal        string
+	DateTimeDigitized       string
 	ComponentsConfiguration string
-	ShutterSpeedValue string
-	ApertureValue string
-	BrightnessValue string
-	ExposureBiasValue string
-	MeteringMode int
-	Flash int
-	FocalLength string
-	SubjectArea string
-	MakerNote string
-	SubSecTimeOriginal string
-	SubSecTimeDigitized string
-	ColorSpace int
-	PixelXDimension int
-	PixelYDimension int
-	SensingMethod int
-	SceneType string
-	ExposureMode int
-	WhiteBalance int
-	FocalLengthIn35mmFilm int
-	SceneCaptureType int
-	GPSLatitudeRef string
-	GPSLatitude string
-	GPSLongitudeRef string
-	GPSLongitude string
-	GPSAltitudeRef string
-	GPSAltitude string
-	GPSSpeedRef string
-	GPSSpeed string
-	GPSImgDirectionRef string
-	GPSImgDirection string
-	GPSDestBearingRef string
-	GPSDestBearing string
-	GPSDateStamp string
+	ShutterSpeedValue       string
+	ApertureValue           string
+	BrightnessValue         string
+	ExposureBiasValue       string
+	MeteringMode            int
+	Flash                   int
+	FocalLength             string
+	SubjectArea             string
+	MakerNote               string
+	SubSecTimeOriginal      string
+	SubSecTimeDigitized     string
+	ColorSpace              int
+	PixelXDimension         int
+	PixelYDimension         int
+	SensingMethod           int
+	SceneType               string
+	ExposureMode            int
+	WhiteBalance            int
+	FocalLengthIn35mmFilm   int
+	SceneCaptureType        int
+	GPSLatitudeRef          string
+	GPSLatitude             string
+	GPSLongitudeRef         string
+	GPSLongitude            string
+	GPSAltitudeRef          string
+	GPSAltitude             string
+	GPSSpeedRef             string
+	GPSSpeed                string
+	GPSImgDirectionRef      string
+	GPSImgDirection         string
+	GPSDestBearingRef       string
+	GPSDestBearing          string
+	GPSDateStamp            string
 }
 
 // Size returns the image size by width and height pixels.
@@ -170,72 +170,72 @@ func Metadata(buf []byte) (ImageMetadata, error) {
 	defer C.g_object_unref(C.gpointer(image))
 
 	size := ImageSize{
-		Width:  int(image.Xsize),
-		Height: int(image.Ysize),
+		Width:  int(image.c.Xsize),
+		Height: int(image.c.Ysize),
 	}
 
 	orientation := vipsExifIntTag(image, Orientation)
 
 	metadata := ImageMetadata{
 		Size:        size,
-		Channels:    int(image.Bands),
+		Channels:    int(image.c.Bands),
 		Orientation: orientation,
 		Alpha:       vipsHasAlpha(image),
 		Profile:     vipsHasProfile(image),
 		Space:       vipsSpace(image),
 		Type:        ImageTypeName(imageType),
 		EXIF: EXIF{
-			Make: vipsExifStringTag(image, Make),
-			Model: vipsExifStringTag(image, Model),
-			Orientation: orientation,
-			XResolution: vipsExifStringTag(image, XResolution),
-			YResolution: vipsExifStringTag(image, YResolution),
-			ResolutionUnit: vipsExifIntTag(image, ResolutionUnit),
-			Software: vipsExifStringTag(image, Software),
-			Datetime: vipsExifStringTag(image, Datetime),
-			YCbCrPositioning: vipsExifIntTag(image, YCbCrPositioning),
-			Compression: vipsExifIntTag(image, Compression),
-			ExposureTime: vipsExifStringTag(image, ExposureTime),
-			FNumber: vipsExifStringTag(image, FNumber),
-			ExposureProgram: vipsExifIntTag(image, ExposureProgram),
-			ISOSpeedRatings: vipsExifIntTag(image, ISOSpeedRatings),
-			ExifVersion: vipsExifStringTag(image, ExifVersion),
-			DateTimeOriginal: vipsExifStringTag(image, DateTimeOriginal),
-			DateTimeDigitized: vipsExifStringTag(image, DateTimeDigitized),
+			Make:                    vipsExifStringTag(image, Make),
+			Model:                   vipsExifStringTag(image, Model),
+			Orientation:             orientation,
+			XResolution:             vipsExifStringTag(image, XResolution),
+			YResolution:             vipsExifStringTag(image, YResolution),
+			ResolutionUnit:          vipsExifIntTag(image, ResolutionUnit),
+			Software:                vipsExifStringTag(image, Software),
+			Datetime:                vipsExifStringTag(image, Datetime),
+			YCbCrPositioning:        vipsExifIntTag(image, YCbCrPositioning),
+			Compression:             vipsExifIntTag(image, Compression),
+			ExposureTime:            vipsExifStringTag(image, ExposureTime),
+			FNumber:                 vipsExifStringTag(image, FNumber),
+			ExposureProgram:         vipsExifIntTag(image, ExposureProgram),
+			ISOSpeedRatings:         vipsExifIntTag(image, ISOSpeedRatings),
+			ExifVersion:             vipsExifStringTag(image, ExifVersion),
+			DateTimeOriginal:        vipsExifStringTag(image, DateTimeOriginal),
+			DateTimeDigitized:       vipsExifStringTag(image, DateTimeDigitized),
 			ComponentsConfiguration: vipsExifStringTag(image, ComponentsConfiguration),
-			ShutterSpeedValue: vipsExifStringTag(image, ShutterSpeedValue),
-			ApertureValue: vipsExifStringTag(image, ApertureValue),
-			BrightnessValue: vipsExifStringTag(image, BrightnessValue),
-			ExposureBiasValue: vipsExifStringTag(image, ExposureBiasValue),
-			MeteringMode: vipsExifIntTag(image, MeteringMode),
-			Flash: vipsExifIntTag(image, Flash),
-			FocalLength: vipsExifStringTag(image, FocalLength),
-			SubjectArea: vipsExifStringTag(image, SubjectArea),
-			MakerNote: vipsExifStringTag(image, MakerNote),
-			SubSecTimeOriginal: vipsExifStringTag(image, SubSecTimeOriginal),
-			SubSecTimeDigitized: vipsExifStringTag(image, SubSecTimeDigitized),
-			ColorSpace: vipsExifIntTag(image, ColorSpace),
-			PixelXDimension: vipsExifIntTag(image, PixelXDimension),
-			PixelYDimension: vipsExifIntTag(image, PixelYDimension),
-			SensingMethod: vipsExifIntTag(image, SensingMethod),
-			SceneType: vipsExifStringTag(image, SceneType),
-			ExposureMode: vipsExifIntTag(image, ExposureMode),
-			WhiteBalance: vipsExifIntTag(image, WhiteBalance),
-			FocalLengthIn35mmFilm: vipsExifIntTag(image, FocalLengthIn35mmFilm),
-			SceneCaptureType: vipsExifIntTag(image, SceneCaptureType),
-			GPSLatitudeRef: vipsExifStringTag(image, GPSLatitudeRef),
-			GPSLatitude: vipsExifStringTag(image, GPSLatitude),
-			GPSLongitudeRef: vipsExifStringTag(image, GPSLongitudeRef),
-			GPSLongitude: vipsExifStringTag(image, GPSLongitude),
-			GPSAltitudeRef: vipsExifStringTag(image, GPSAltitudeRef),
-			GPSAltitude: vipsExifStringTag(image, GPSAltitude),
-			GPSSpeedRef: vipsExifStringTag(image, GPSSpeedRef),
-			GPSSpeed: vipsExifStringTag(image, GPSSpeed),
-			GPSImgDirectionRef: vipsExifStringTag(image, GPSImgDirectionRef),
-			GPSImgDirection: vipsExifStringTag(image, GPSImgDirection),
-			GPSDestBearingRef: vipsExifStringTag(image, GPSDestBearingRef),
-			GPSDestBearing: vipsExifStringTag(image, GPSDestBearing),
-			GPSDateStamp: vipsExifStringTag(image, GPSDateStamp),
+			ShutterSpeedValue:       vipsExifStringTag(image, ShutterSpeedValue),
+			ApertureValue:           vipsExifStringTag(image, ApertureValue),
+			BrightnessValue:         vipsExifStringTag(image, BrightnessValue),
+			ExposureBiasValue:       vipsExifStringTag(image, ExposureBiasValue),
+			MeteringMode:            vipsExifIntTag(image, MeteringMode),
+			Flash:                   vipsExifIntTag(image, Flash),
+			FocalLength:             vipsExifStringTag(image, FocalLength),
+			SubjectArea:             vipsExifStringTag(image, SubjectArea),
+			MakerNote:               vipsExifStringTag(image, MakerNote),
+			SubSecTimeOriginal:      vipsExifStringTag(image, SubSecTimeOriginal),
+			SubSecTimeDigitized:     vipsExifStringTag(image, SubSecTimeDigitized),
+			ColorSpace:              vipsExifIntTag(image, ColorSpace),
+			PixelXDimension:         vipsExifIntTag(image, PixelXDimension),
+			PixelYDimension:         vipsExifIntTag(image, PixelYDimension),
+			SensingMethod:           vipsExifIntTag(image, SensingMethod),
+			SceneType:               vipsExifStringTag(image, SceneType),
+			ExposureMode:            vipsExifIntTag(image, ExposureMode),
+			WhiteBalance:            vipsExifIntTag(image, WhiteBalance),
+			FocalLengthIn35mmFilm:   vipsExifIntTag(image, FocalLengthIn35mmFilm),
+			SceneCaptureType:        vipsExifIntTag(image, SceneCaptureType),
+			GPSLatitudeRef:          vipsExifStringTag(image, GPSLatitudeRef),
+			GPSLatitude:             vipsExifStringTag(image, GPSLatitude),
+			GPSLongitudeRef:         vipsExifStringTag(image, GPSLongitudeRef),
+			GPSLongitude:            vipsExifStringTag(image, GPSLongitude),
+			GPSAltitudeRef:          vipsExifStringTag(image, GPSAltitudeRef),
+			GPSAltitude:             vipsExifStringTag(image, GPSAltitude),
+			GPSSpeedRef:             vipsExifStringTag(image, GPSSpeedRef),
+			GPSSpeed:                vipsExifStringTag(image, GPSSpeed),
+			GPSImgDirectionRef:      vipsExifStringTag(image, GPSImgDirectionRef),
+			GPSImgDirection:         vipsExifStringTag(image, GPSImgDirection),
+			GPSDestBearingRef:       vipsExifStringTag(image, GPSDestBearingRef),
+			GPSDestBearing:          vipsExifStringTag(image, GPSDestBearing),
+			GPSDateStamp:            vipsExifStringTag(image, GPSDateStamp),
 		},
 	}
 

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -89,7 +89,7 @@ func TestImageInterpretation(t *testing.T) {
 }
 
 func TestEXIF(t *testing.T) {
-	if VipsMajorVersion <= 8 && VipsMinorVersion < 10 {
+	if !vipsVersionMin(8, 10) {
 		t.Skip("Skip test in libvips < 8.10")
 		return
 	}

--- a/options.go
+++ b/options.go
@@ -142,13 +142,15 @@ const (
 // WatermarkFont defines the default watermark font to be used.
 var WatermarkFont = "sans 10"
 
-// Color represents a traditional RGB color scheme.
+// Color represents a traditional RGBA color scheme.
 type Color struct {
-	R, G, B uint8
+	R, G, B, A uint8
 }
 
 // ColorBlack is a shortcut to black RGB color representation.
-var ColorBlack = Color{0, 0, 0}
+var ColorBlack = Color{0x00, 0x00, 0x00, 0xFF}
+// ColorWhite is a shortcut to white RGB color representation.
+var ColorWhite = Color{0xFF, 0xFF, 0xFF, 0xFF}
 
 // Watermark represents the text-based watermark supported options.
 type Watermark struct {

--- a/options.go
+++ b/options.go
@@ -142,15 +142,38 @@ const (
 // WatermarkFont defines the default watermark font to be used.
 var WatermarkFont = "sans 10"
 
-// Color represents a traditional RGBA color scheme.
+// Color represents a traditional RGB color scheme.
 type Color struct {
-	R, G, B, A uint8
+	R, G, B uint8
+}
+
+// RGBA returns the color with full opacity.
+func (c Color) RGBA() (r uint8, g uint8, b uint8, a uint8) {
+	return c.R, c.G, c.B, 0xFF
+}
+
+// ColorWithAlpha represents a traditional RGBA color scheme.
+// It uses Color as base for easier reusability of already defined colors.
+type ColorWithAlpha struct {
+	Color
+	A uint8
+}
+
+// RGBA returns the color with the specified alpha value.
+func (c ColorWithAlpha) RGBA() (r uint8, g uint8, b uint8, a uint8) {
+	return c.R, c.G, c.B, c.A
+}
+
+// RGBAProvider defines the interface required to get RGBA compatible
+// color channels.
+type RGBAProvider interface {
+	RGBA() (r uint8, g uint8, b uint8, a uint8)
 }
 
 // ColorBlack is a shortcut to black RGB color representation.
-var ColorBlack = Color{0x00, 0x00, 0x00, 0xFF}
+var ColorBlack = Color{0x00, 0x00, 0x00}
 // ColorWhite is a shortcut to white RGB color representation.
-var ColorWhite = Color{0xFF, 0xFF, 0xFF, 0xFF}
+var ColorWhite = Color{0xFF, 0xFF, 0xFF}
 
 // Watermark represents the text-based watermark supported options.
 type Watermark struct {
@@ -214,7 +237,7 @@ type Options struct {
 	Lossless       bool
 	Extend         Extend
 	Rotate         Angle
-	Background     Color
+	Background     RGBAProvider
 	Gravity        Gravity
 	Watermark      Watermark
 	WatermarkImage WatermarkImage

--- a/options.go
+++ b/options.go
@@ -172,6 +172,7 @@ type RGBAProvider interface {
 
 // ColorBlack is a shortcut to black RGB color representation.
 var ColorBlack = Color{0x00, 0x00, 0x00}
+
 // ColorWhite is a shortcut to white RGB color representation.
 var ColorWhite = Color{0xFF, 0xFF, 0xFF}
 
@@ -184,7 +185,7 @@ type Watermark struct {
 	NoReplicate bool
 	Text        string
 	Font        string
-	Background  Color
+	Background  RGBAProvider
 }
 
 // WatermarkImage represents the image-based watermark supported options.

--- a/resizer.go
+++ b/resizer.go
@@ -263,35 +263,22 @@ func extractOrEmbedImage(image *vipsImage, o ResizeOptions) (*vipsImage, error) 
 	return image, err
 }
 
-func rotateAndFlipImage(image *vipsImage, o RotateOptions) (*vipsImage, bool, error) {
+func rotateAndFlipImage(image *vipsImage, o RotateOptions) (*vipsImage, error) {
 	var err error
-	var rotated bool
-
-	if o.NoAutoRotate == false {
-		rotation, flip := calculateRotationAndFlip(image, o.Angle)
-		if flip {
-			o.Flip = flip
-		}
-		if rotation > 0 && o.Angle == 0 {
-			o.Angle = rotation
-		}
-	}
 
 	if o.Angle > 0 {
-		rotated = true
 		image, err = vipsRotate(image, getAngle(o.Angle))
 	}
 
 	if o.Flip {
-		rotated = true
 		image, err = vipsFlip(image, Horizontal)
 	}
 
 	if o.Flop {
-		rotated = true
 		image, err = vipsFlip(image, Vertical)
 	}
-	return image, rotated, err
+
+	return image, err
 }
 
 func watermarkImageWithText(image *vipsImage, w Watermark) (*vipsImage, error) {

--- a/resizer.go
+++ b/resizer.go
@@ -403,7 +403,9 @@ func watermarkImageWithAnotherImage(image *C.VipsImage, w WatermarkImage) (*C.Vi
 }
 
 func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsImage, error) {
-	if o.Background == ColorBlack {
+	// If no alpha channel is set, there is nothing to flatten. We basically assume that the
+	// background stays untouched.
+	if o.Background.A == 0 {
 		return image, nil
 	}
 	return vipsFlattenBackground(image, o.Background)

--- a/resizer.go
+++ b/resizer.go
@@ -113,9 +113,20 @@ func resizer(buf []byte, o Options) ([]byte, error) {
 }
 
 func resizeIfNecessary(t *ImageTransformation, o Options) error {
-	if (o.Crop || o.Embed) && !o.Force && !o.Enlarge {
-		// Nothing to do.
-		return nil
+	imageSize := t.Size()
+
+	if o.Crop || o.Embed {
+		if o.Width == 0 {
+			o.Width = imageSize.Width
+		}
+		if o.Height == 0 {
+			o.Height = imageSize.Height
+		}
+
+		if !o.Force && !o.Enlarge && imageSize.Width < o.Width && imageSize.Height < o.Height {
+			// Nothing to do.
+			return nil
+		}
 	}
 
 	var resizeMode ResizeMode

--- a/resizer.go
+++ b/resizer.go
@@ -403,11 +403,17 @@ func watermarkImageWithAnotherImage(image *C.VipsImage, w WatermarkImage) (*C.Vi
 }
 
 func imageFlatten(image *C.VipsImage, imageType ImageType, o Options) (*C.VipsImage, error) {
-	// If no alpha channel is set, there is nothing to flatten. We basically assume that the
-	// background stays untouched.
-	if o.Background.A == 0 {
+	// If no background is set, we cannot flatten anything. Just skip.
+	if o.Background == nil {
 		return image, nil
 	}
+	// If an alpha channel is set, but is not full opacity, we should not flatten, since it would
+	// purge the alpha channel.
+	_, _, _, a := o.Background.RGBA()
+	if a < 0xFF {
+		return image, nil
+	}
+
 	return vipsFlattenBackground(image, o.Background)
 }
 

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -511,37 +511,39 @@ func TestRotationAndFlip(t *testing.T) {
 	}
 
 	for _, file := range files {
-		img, err := os.Open(fmt.Sprintf("testdata/exif/%s.jpg", file.Name))
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run(file.Name, func(t *testing.T) {
+			img, err := os.Open(fmt.Sprintf("testdata/exif/%s.jpg", file.Name))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		buf, err := ioutil.ReadAll(img)
-		if err != nil {
-			t.Fatal(err)
-		}
-		img.Close()
+			buf, err := ioutil.ReadAll(img)
+			if err != nil {
+				t.Fatal(err)
+			}
+			img.Close()
 
-		image, _, err := loadImage(buf)
-		if err != nil {
-			t.Fatal(err)
-		}
+			image, _, err := loadImage(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		angle, flip := calculateRotationAndFlip(image, D0)
-		if angle != file.Angle {
-			t.Errorf("Rotation for %v expected to be %v. got %v", file.Name, file.Angle, angle)
-		}
-		if flip != file.Flip {
-			t.Errorf("Flip for %v expected to be %v. got %v", file.Name, file.Flip, flip)
-		}
+			angle, flip := calculateRotationAndFlip(image, D0)
+			if angle != file.Angle {
+				t.Errorf("Rotation for %v expected to be %v. got %v", file.Name, file.Angle, angle)
+			}
+			if flip != file.Flip {
+				t.Errorf("Flip for %v expected to be %v. got %v", file.Name, file.Flip, flip)
+			}
 
-		// Visual debugging.
-		newImg, err := Resize(buf, Options{})
-		if err != nil {
-			t.Fatal(err)
-		}
+			// Visual debugging.
+			newImg, err := Resize(buf, Options{})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		Write(fmt.Sprintf("testdata/exif/%s_out.jpg", file.Name), newImg)
+			Write(fmt.Sprintf("testdata/exif/%s_out.jpg", file.Name), newImg)
+		})
 	}
 }
 

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -263,7 +263,7 @@ func TestNoColorProfile(t *testing.T) {
 }
 
 func TestEmbedExtendColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10, 255}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -280,7 +280,7 @@ func TestEmbedExtendColor(t *testing.T) {
 }
 
 func TestEmbedExtendWithCustomColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10, 255}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -790,7 +790,7 @@ func BenchmarkWatermarkJpeg(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.jpg", options, b)
@@ -805,7 +805,7 @@ func BenchmarkWatermarkPng(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.png", options, b)
@@ -820,7 +820,7 @@ func BenchmarkWatermarkWebp(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255},
+			Background: Color{255, 255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.webp", options, b)

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -393,7 +393,7 @@ func TestExtractOrEmbedImage(t *testing.T) {
 		t.Fatalf("Unable to load image %s", err)
 	}
 
-	o := ResizeOptions{
+	o := Options{
 		Top:    10,
 		Left:   10,
 		Width:  100,
@@ -404,15 +404,13 @@ func TestExtractOrEmbedImage(t *testing.T) {
 		AreaWidth:  0,
 	}
 
-	result, err := extractOrEmbedImage(transform.image, o)
-	if err != nil {
+	if err := extractOrEmbedImage(transform, o); err != nil {
 		if errors.Unwrap(err) == ErrExtractAreaParamsRequired {
 			t.Fatalf("Expecting AreaWidth and AreaHeight to have been defined")
 		}
 
 		t.Fatalf("Unknown error occurred %s", err)
 	}
-	transform.updateImage(result)
 
 	image, err := transform.Save(SaveOptions{Quality: 100})
 	if err != nil {

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +35,27 @@ func TestResize(t *testing.T) {
 	Write("testdata/test_out.jpg", newImg)
 }
 
+func formatOptions(o Options) string {
+	var attributes []string
+	if o.Crop {
+		attributes = append(attributes, "Crop")
+	}
+	if o.Enlarge {
+		attributes = append(attributes, "Enlarge")
+	}
+	if o.Force {
+		attributes = append(attributes, "Force")
+	}
+	if o.Width > 0 {
+		attributes = append(attributes, fmt.Sprintf("Width=%d", o.Width))
+	}
+	if o.Height > 0 {
+		attributes = append(attributes, fmt.Sprintf("Height=%d", o.Height))
+	}
+
+	return fmt.Sprintf("Options{%s}", strings.Join(attributes, ","))
+}
+
 func TestResizeVerticalImage(t *testing.T) {
 	tests := []Options{
 		{Width: 800, Height: 600},
@@ -52,51 +74,50 @@ func TestResizeVerticalImage(t *testing.T) {
 		{Force: true, Width: 2000, Height: 2000},
 	}
 
-	bufJpeg, err := Read("testdata/vertical.jpg")
-	if err != nil {
-		t.Fatal(err)
-	}
-	bufWebp, err := Read("testdata/vertical.webp")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	images := []struct {
 		format ImageType
-		buf    []byte
+		file   string
 	}{
-		{JPEG, bufJpeg},
-		{WEBP, bufWebp},
+		{JPEG, "testdata/vertical.jpg"},
+		{WEBP, "testdata/vertical.webp"},
 	}
 
 	for _, source := range images {
-		for _, options := range tests {
-			image, err := Resize(source.buf, options)
+		t.Run(source.file, func(t *testing.T) {
+			buf, err := Read(source.file)
 			if err != nil {
-				t.Fatalf("Resize(imgData, %#v) error: %#v", options, err)
+				t.Fatal(err)
 			}
+			for _, options := range tests {
+				t.Run(formatOptions(options), func(t *testing.T) {
+					image, err := Resize(buf, options)
+					if err != nil {
+						t.Fatalf("Resize(imgData, %#v) error: %#v", options, err)
+					}
 
-			format := DetermineImageType(image)
-			if format != source.format {
-				t.Fatalf("Image format is invalid. Expected: %#v got %v", ImageTypeName(source.format), ImageTypeName(format))
-			}
+					format := DetermineImageType(image)
+					if format != source.format {
+						t.Fatalf("Image format is invalid. Expected: %#v got %v", ImageTypeName(source.format), ImageTypeName(format))
+					}
 
-			size, _ := Size(image)
-			if options.Height > 0 && size.Height != options.Height {
-				t.Fatalf("Invalid height: %d", size.Height)
-			}
-			if options.Width > 0 && size.Width != options.Width {
-				t.Fatalf("Invalid width: %d", size.Width)
-			}
+					size, _ := Size(image)
+					if options.Height > 0 && size.Height != options.Height {
+						t.Fatalf("Invalid height: %d", size.Height)
+					}
+					if options.Width > 0 && size.Width != options.Width {
+						t.Fatalf("Invalid width: %d", size.Width)
+					}
 
-			Write(
-				fmt.Sprintf(
-					"testdata/test_vertical_%dx%d_out.%s",
-					options.Width,
-					options.Height,
-					ImageTypeName(source.format)),
-				image)
-		}
+					Write(
+						fmt.Sprintf(
+							"testdata/test_vertical_%dx%d_out.%s",
+							options.Width,
+							options.Height,
+							ImageTypeName(source.format)),
+						image)
+				})
+			}
+		})
 	}
 }
 
@@ -115,50 +136,50 @@ func TestResizeCustomSizes(t *testing.T) {
 		{Force: true, Width: 2000, Height: 2000},
 	}
 
-	bufJpeg, err := Read("testdata/test.jpg")
-	if err != nil {
-		t.Fatal(err)
-	}
-	bufWebp, err := Read("testdata/test.webp")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	images := []struct {
 		format ImageType
-		buf    []byte
+		file   string
 	}{
-		{JPEG, bufJpeg},
-		{WEBP, bufWebp},
+		{JPEG, "testdata/test.jpg"},
+		{WEBP, "testdata/test.webp"},
 	}
 
 	for _, source := range images {
-		for _, options := range tests {
-			image, err := Resize(source.buf, options)
+		t.Run(source.file, func(t *testing.T) {
+			buf, err := Read(source.file)
 			if err != nil {
-				t.Errorf("Resize(imgData, %#v) error: %#v", options, err)
+				t.Fatal(err)
 			}
 
-			if DetermineImageType(image) != source.format {
-				t.Fatalf("Image format is invalid. Expected: %#v", source.format)
-			}
+			for _, options := range tests {
+				t.Run(formatOptions(options), func(t *testing.T) {
+					image, err := Resize(buf, options)
+					if err != nil {
+						t.Errorf("Resize(imgData, %#v) error: %#v", options, err)
+					}
 
-			size, _ := Size(image)
+					if DetermineImageType(image) != source.format {
+						t.Fatalf("Image format is invalid. Expected: %#v", source.format)
+					}
 
-			invalidHeight := options.Height > 0 && size.Height != options.Height
-			if !options.Crop && invalidHeight {
-				t.Fatalf("Invalid height: %d, expected %d", size.Height, options.Height)
-			}
+					size, _ := Size(image)
 
-			invalidWidth := options.Width > 0 && size.Width != options.Width
-			if !options.Crop && invalidWidth {
-				t.Fatalf("Invalid width: %d, expected %d", size.Width, options.Width)
-			}
+					invalidHeight := options.Height > 0 && size.Height != options.Height
+					if !options.Crop && invalidHeight {
+						t.Fatalf("Invalid height: %d, expected %d", size.Height, options.Height)
+					}
 
-			if options.Crop && invalidHeight && invalidWidth {
-				t.Fatalf("Invalid width or height: %dx%d, expected %dx%d (crop)", size.Width, size.Height, options.Width, options.Height)
+					invalidWidth := options.Width > 0 && size.Width != options.Width
+					if !options.Crop && invalidWidth {
+						t.Fatalf("Invalid width: %d, expected %d", size.Width, options.Width)
+					}
+
+					if options.Crop && invalidHeight && invalidWidth {
+						t.Fatalf("Invalid width or height: %dx%d, expected %dx%d (crop)", size.Width, size.Height, options.Width, options.Height)
+					}
+				})
 			}
-		}
+		})
 	}
 }
 

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -3,6 +3,7 @@ package bimg
 import (
 	"bytes"
 	"crypto/md5"
+	"errors"
 	"fmt"
 	"image"
 	"image/jpeg"
@@ -382,13 +383,15 @@ func TestExtractOrEmbedImage(t *testing.T) {
 		AreaWidth:  0,
 	}
 
-	if err := transform.Resize(o); err != nil {
-		if err == ErrExtractAreaParamsRequired {
+	result, err := extractOrEmbedImage(transform.image, o)
+	if err != nil {
+		if errors.Unwrap(err) == ErrExtractAreaParamsRequired {
 			t.Fatalf("Expecting AreaWidth and AreaHeight to have been defined")
 		}
 
 		t.Fatalf("Unknown error occurred %s", err)
 	}
+	transform.updateImage(result)
 
 	image, err := transform.Save(SaveOptions{Quality: 100})
 	if err != nil {

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -366,12 +366,12 @@ func TestExtractCustomAxis(t *testing.T) {
 
 func TestExtractOrEmbedImage(t *testing.T) {
 	buf, _ := Read("testdata/test.jpg")
-	input, _, err := loadImage(buf)
+	transform, err := NewImageTransformation(buf)
 	if err != nil {
 		t.Fatalf("Unable to load image %s", err)
 	}
 
-	o := Options{
+	o := ResizeOptions{
 		Top:    10,
 		Left:   10,
 		Width:  100,
@@ -380,12 +380,9 @@ func TestExtractOrEmbedImage(t *testing.T) {
 		// Fields to test
 		AreaHeight: 0,
 		AreaWidth:  0,
-
-		Quality: 100, /* Needs a value to satisfy libvips */
 	}
 
-	result, err := extractOrEmbedImage(input, o)
-	if err != nil {
+	if err := transform.Resize(o); err != nil {
 		if err == ErrExtractAreaParamsRequired {
 			t.Fatalf("Expecting AreaWidth and AreaHeight to have been defined")
 		}
@@ -393,7 +390,7 @@ func TestExtractOrEmbedImage(t *testing.T) {
 		t.Fatalf("Unknown error occurred %s", err)
 	}
 
-	image, err := saveImage(result, o)
+	image, err := transform.Save(SaveOptions{Quality: 100})
 	if err != nil {
 		t.Fatalf("Failed saving image %s", err)
 	}

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -548,7 +548,7 @@ func TestRotationAndFlip(t *testing.T) {
 }
 
 func TestIfBothSmartCropOptionsAreIdentical(t *testing.T) {
-	if !(VipsMajorVersion >= 8 && VipsMinorVersion > 4) {
+	if !(vipsVersionMin(8, 5)) {
 		t.Skipf("Skipping this test, libvips doesn't meet version requirement %s > 8.4", VipsVersion)
 	}
 

--- a/resizer_test.go
+++ b/resizer_test.go
@@ -263,7 +263,7 @@ func TestNoColorProfile(t *testing.T) {
 }
 
 func TestEmbedExtendColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10, 255}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: ExtendWhite, Background: Color{255, 20, 10}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -280,7 +280,7 @@ func TestEmbedExtendColor(t *testing.T) {
 }
 
 func TestEmbedExtendWithCustomColor(t *testing.T) {
-	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10, 255}}
+	options := Options{Width: 400, Height: 600, Crop: false, Embed: true, Extend: 5, Background: Color{255, 20, 10}}
 	buf, _ := Read("testdata/test_issue.jpg")
 
 	newImg, err := Resize(buf, options)
@@ -790,7 +790,7 @@ func BenchmarkWatermarkJpeg(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255, 255},
+			Background: Color{255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.jpg", options, b)
@@ -805,7 +805,7 @@ func BenchmarkWatermarkPng(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255, 255},
+			Background: Color{255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.png", options, b)
@@ -820,7 +820,7 @@ func BenchmarkWatermarkWebp(b *testing.B) {
 			DPI:        100,
 			Margin:     150,
 			Font:       "sans bold 12",
-			Background: Color{255, 255, 255, 255},
+			Background: Color{255, 255, 255},
 		},
 	}
 	runBenchmarkResize("test.webp", options, b)

--- a/transformation.go
+++ b/transformation.go
@@ -150,7 +150,7 @@ func (it *ImageTransformation) Resize(opts ResizeOptions) error {
 	// Try to use libjpeg/libwebp shrink-on-load, if the buffer is still usable.
 	// If we performed "destructive" transformations already, this will no longer
 	// be the case.
-	isShrinkableWebP := it.imageType == WEBP && VipsMajorVersion >= 8 && VipsMinorVersion >= 3
+	isShrinkableWebP := it.imageType == WEBP && vipsVersionMin(8, 3)
 	isShrinkableJpeg := it.imageType == JPEG
 	supportsShrinkOnLoad := !it.bufTainted && (isShrinkableWebP || isShrinkableJpeg)
 

--- a/transformation.go
+++ b/transformation.go
@@ -193,7 +193,19 @@ type RotateOptions struct {
 }
 
 func (it *ImageTransformation) Rotate(opts RotateOptions) error {
-	image, _, err := rotateAndFlipImage(it.image, opts)
+	var image *vipsImage
+	var err error
+
+	if opts.NoAutoRotate {
+		image = it.image
+	} else {
+		image, err = vipsAutoRotate(it.image)
+		if err != nil {
+			return fmt.Errorf("cannot autorotate image: %w", err)
+		}
+	}
+
+	image, err = rotateAndFlipImage(image, opts)
 	if err != nil {
 		return err
 	}

--- a/transformation.go
+++ b/transformation.go
@@ -1,11 +1,21 @@
 package bimg
 
+/*
+#cgo pkg-config: vips
+#include "vips/vips.h"
+*/
 import "C"
-import "runtime"
+import (
+	"fmt"
+	"math"
+	"runtime"
+)
 
 type ImageTransformation struct {
-	image     *C.VipsImage
-	imageType ImageType
+	buf        []byte
+	bufTainted bool
+	image      *C.VipsImage
+	imageType  ImageType
 }
 
 func NewImageTransformation(buf []byte) (*ImageTransformation, error) {
@@ -14,8 +24,10 @@ func NewImageTransformation(buf []byte) (*ImageTransformation, error) {
 		return nil, err
 	}
 	it := &ImageTransformation{
-		image:     image,
-		imageType: imageType,
+		buf:        buf,
+		bufTainted: false,
+		image:      image,
+		imageType:  imageType,
 	}
 	runtime.SetFinalizer(it, finalizeImageTransformation)
 	return it, nil
@@ -23,8 +35,10 @@ func NewImageTransformation(buf []byte) (*ImageTransformation, error) {
 
 func (it *ImageTransformation) Clone() *ImageTransformation {
 	clone := &ImageTransformation{
-		image:     it.image,
-		imageType: it.imageType,
+		buf:        it.buf,
+		bufTainted: it.bufTainted,
+		image:      it.image,
+		imageType:  it.imageType,
 	}
 	C.g_object_ref(C.gpointer(clone.image))
 	runtime.SetFinalizer(it, finalizeImageTransformation)
@@ -41,6 +55,239 @@ func finalizeImageTransformation(it *ImageTransformation) {
 }
 
 func (it *ImageTransformation) updateImage(image *C.VipsImage) {
+	if it.image == image {
+		return
+	}
+
 	C.g_object_unref(C.gpointer(it.image))
 	it.image = image
+	// We replaced the image, so the buffer is no longer the same content.
+	it.bufTainted = true
 }
+
+type ResizeOptions struct {
+	Height         int
+	Width          int
+	AreaHeight     int
+	AreaWidth      int
+	Top            int
+	Left           int
+	Zoom           int
+	Crop           bool
+	Enlarge        bool
+	Embed          bool
+	Force          bool
+	Trim           bool
+	Extend         Extend
+	Background     RGBAProvider
+	Gravity        Gravity
+	Interpolator   Interpolator
+	Interpretation Interpretation
+	Threshold      float64
+}
+
+func calculateResizeFactor(opts *ResizeOptions, inWidth, inHeight int) float64 {
+	factor := 1.0
+	xfactor := float64(inWidth) / float64(opts.Width)
+	yfactor := float64(inHeight) / float64(opts.Height)
+
+	switch {
+	// Fixed width and height
+	case opts.Width > 0 && opts.Height > 0:
+		if opts.Crop {
+			factor = math.Min(xfactor, yfactor)
+		} else {
+			factor = math.Max(xfactor, yfactor)
+		}
+	// Fixed width, auto height
+	case opts.Width > 0:
+		if opts.Crop {
+			opts.Height = inHeight
+		} else {
+			factor = xfactor
+			opts.Height = roundFloat(float64(inHeight) / factor)
+		}
+	// Fixed height, auto width
+	case opts.Height > 0:
+		if opts.Crop {
+			opts.Width = inWidth
+		} else {
+			factor = yfactor
+			opts.Width = roundFloat(float64(inWidth) / factor)
+		}
+	// Identity transform
+	default:
+		opts.Width = inWidth
+		opts.Height = inHeight
+		break
+	}
+
+	return factor
+}
+
+func (it *ImageTransformation) Resize(opts ResizeOptions) error {
+	if opts.Interpretation == 0 {
+		opts.Interpretation = InterpretationSRGB
+	}
+	if !opts.Force && !opts.Crop && !opts.Embed && !opts.Enlarge && (opts.Width > 0 || opts.Height > 0) {
+		opts.Force = true
+	}
+
+	inWidth := int(it.image.Xsize)
+	inHeight := int(it.image.Ysize)
+
+	// image calculations
+	factor := calculateResizeFactor(&opts, inWidth, inHeight)
+	shrink := calculateShrink(factor, opts.Interpolator)
+	residual := calculateResidual(factor, shrink)
+
+	// Do not enlarge the output if the input width or height
+	// are already less than the required dimensions
+	if !opts.Enlarge && !opts.Force {
+		if inWidth < opts.Width && inHeight < opts.Height {
+			factor = 1.0
+			shrink = 1
+			residual = 0
+			opts.Width = inWidth
+			opts.Height = inHeight
+		}
+	}
+
+	// Try to use libjpeg/libwebp shrink-on-load, if the buffer is still usable.
+	// If we performed "destructive" transformations already, this will no longer
+	// be the case.
+	isShrinkableWebP := it.imageType == WEBP && VipsMajorVersion >= 8 && VipsMinorVersion >= 3
+	isShrinkableJpeg := it.imageType == JPEG
+	supportsShrinkOnLoad := !it.bufTainted && (isShrinkableWebP || isShrinkableJpeg)
+
+	if supportsShrinkOnLoad && shrink >= 2 {
+		tmpImage, factor, err := shrinkOnLoad(it.buf, it.image, it.imageType, factor, shrink)
+		if err != nil {
+			return fmt.Errorf("cannot shrink-on-load: %w", err)
+		}
+
+		it.updateImage(tmpImage)
+		factor = math.Max(factor, 1.0)
+		shrink = int(math.Floor(factor))
+		residual = float64(shrink) / factor
+	}
+
+	// Zoom image, if necessary
+	if image, err := zoomImage(it.image, opts.Zoom); err != nil {
+		return fmt.Errorf("cannot zoom image: %w", err)
+	} else {
+		it.updateImage(image)
+	}
+
+	// Transform image, if necessary
+	if shouldTransformImage(opts, inWidth, inHeight) {
+		if image, err := transformImage(it.image, opts, shrink, residual); err != nil {
+			return err
+		} else {
+			it.updateImage(image)
+		}
+	}
+
+	return nil
+}
+
+type RotateOptions struct {
+	Angle        Angle
+	Flip         bool
+	Flop         bool
+	NoAutoRotate bool
+}
+
+func (it *ImageTransformation) Rotate(opts RotateOptions) error {
+	image, _, err := rotateAndFlipImage(it.image, opts)
+	if err != nil {
+		return err
+	}
+	it.updateImage(image)
+
+	// TODO is the following a good idea? Isn't saving always destructive and so time consuming
+	//      that it outweighs the potential time saving when using the optimized shrink?
+	// If it's a JPEG or HEIF image, the rotation might have been non-destructive. So we
+	// update our buffer (which involves saving).
+	//if rotated && (it.imageType == JPEG || it.imageType == HEIF) {
+	//	buf, err := getImageBuffer(image)
+	//	if err != nil {
+	//		return fmt.Errorf("cannot get the rotated image buffer: %w", err)
+	//	}
+	//}
+
+	return nil
+}
+
+func (it *ImageTransformation) Blur(opts GaussianBlur) error {
+	if image, err := vipsGaussianBlur(it.image, opts); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+func (it *ImageTransformation) Sharpen(opts Sharpen) error {
+	if image, err := vipsSharpen(it.image, opts); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+func (it *ImageTransformation) WatermarkText(opts Watermark) error {
+	if image, err := watermarkImageWithText(it.image, opts); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+func (it *ImageTransformation) WatermarkImage(opts WatermarkImage) error {
+	if image, err := watermarkImageWithAnotherImage(it.image, opts); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+func (it *ImageTransformation) Flatten(background RGBAProvider) error {
+	if image, err := vipsFlattenBackground(it.image, background); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+func (it *ImageTransformation) Gamma(gamma float64) error {
+	if image, err := vipsGamma(it.image, gamma); err != nil {
+		return err
+	} else {
+		it.updateImage(image)
+		return nil
+	}
+}
+
+type SaveOptions vipsSaveOptions
+
+func (it *ImageTransformation) Save(opts SaveOptions) ([]byte, error) {
+	// Normalize options first.
+	if opts.Quality == 0 {
+		opts.Quality = Quality
+	}
+	if opts.Compression == 0 {
+		opts.Compression = 6
+	}
+	if opts.Type == 0 {
+		opts.Type = it.imageType
+	}
+
+	return vipsSave(it.image, vipsSaveOptions(opts))
+}
+
+// TODO convert o.SmartCrop to o.Gravity

--- a/transformation.go
+++ b/transformation.go
@@ -389,4 +389,80 @@ func (it *ImageTransformation) Save(opts SaveOptions) ([]byte, error) {
 	return vipsSave(it.image, vipsSaveOptions(opts))
 }
 
+func (it *ImageTransformation) Size() ImageSize {
+	return ImageSize{
+		Width:  int(it.image.c.Xsize),
+		Height: int(it.image.c.Ysize),
+	}
+}
+
+func (it *ImageTransformation) Metadata() ImageMetadata {
+	size := it.Size()
+
+	orientation := vipsExifIntTag(it.image, Orientation)
+
+	return ImageMetadata{
+		Size:        size,
+		Channels:    int(it.image.c.Bands),
+		Orientation: orientation,
+		Alpha:       vipsHasAlpha(it.image),
+		Profile:     vipsHasProfile(it.image),
+		Space:       vipsSpace(it.image),
+		Type:        ImageTypeName(it.imageType),
+		EXIF: EXIF{
+			Make:                    vipsExifStringTag(it.image, Make),
+			Model:                   vipsExifStringTag(it.image, Model),
+			Orientation:             orientation,
+			XResolution:             vipsExifStringTag(it.image, XResolution),
+			YResolution:             vipsExifStringTag(it.image, YResolution),
+			ResolutionUnit:          vipsExifIntTag(it.image, ResolutionUnit),
+			Software:                vipsExifStringTag(it.image, Software),
+			Datetime:                vipsExifStringTag(it.image, Datetime),
+			YCbCrPositioning:        vipsExifIntTag(it.image, YCbCrPositioning),
+			Compression:             vipsExifIntTag(it.image, Compression),
+			ExposureTime:            vipsExifStringTag(it.image, ExposureTime),
+			FNumber:                 vipsExifStringTag(it.image, FNumber),
+			ExposureProgram:         vipsExifIntTag(it.image, ExposureProgram),
+			ISOSpeedRatings:         vipsExifIntTag(it.image, ISOSpeedRatings),
+			ExifVersion:             vipsExifStringTag(it.image, ExifVersion),
+			DateTimeOriginal:        vipsExifStringTag(it.image, DateTimeOriginal),
+			DateTimeDigitized:       vipsExifStringTag(it.image, DateTimeDigitized),
+			ComponentsConfiguration: vipsExifStringTag(it.image, ComponentsConfiguration),
+			ShutterSpeedValue:       vipsExifStringTag(it.image, ShutterSpeedValue),
+			ApertureValue:           vipsExifStringTag(it.image, ApertureValue),
+			BrightnessValue:         vipsExifStringTag(it.image, BrightnessValue),
+			ExposureBiasValue:       vipsExifStringTag(it.image, ExposureBiasValue),
+			MeteringMode:            vipsExifIntTag(it.image, MeteringMode),
+			Flash:                   vipsExifIntTag(it.image, Flash),
+			FocalLength:             vipsExifStringTag(it.image, FocalLength),
+			SubjectArea:             vipsExifStringTag(it.image, SubjectArea),
+			MakerNote:               vipsExifStringTag(it.image, MakerNote),
+			SubSecTimeOriginal:      vipsExifStringTag(it.image, SubSecTimeOriginal),
+			SubSecTimeDigitized:     vipsExifStringTag(it.image, SubSecTimeDigitized),
+			ColorSpace:              vipsExifIntTag(it.image, ColorSpace),
+			PixelXDimension:         vipsExifIntTag(it.image, PixelXDimension),
+			PixelYDimension:         vipsExifIntTag(it.image, PixelYDimension),
+			SensingMethod:           vipsExifIntTag(it.image, SensingMethod),
+			SceneType:               vipsExifStringTag(it.image, SceneType),
+			ExposureMode:            vipsExifIntTag(it.image, ExposureMode),
+			WhiteBalance:            vipsExifIntTag(it.image, WhiteBalance),
+			FocalLengthIn35mmFilm:   vipsExifIntTag(it.image, FocalLengthIn35mmFilm),
+			SceneCaptureType:        vipsExifIntTag(it.image, SceneCaptureType),
+			GPSLatitudeRef:          vipsExifStringTag(it.image, GPSLatitudeRef),
+			GPSLatitude:             vipsExifStringTag(it.image, GPSLatitude),
+			GPSLongitudeRef:         vipsExifStringTag(it.image, GPSLongitudeRef),
+			GPSLongitude:            vipsExifStringTag(it.image, GPSLongitude),
+			GPSAltitudeRef:          vipsExifStringTag(it.image, GPSAltitudeRef),
+			GPSAltitude:             vipsExifStringTag(it.image, GPSAltitude),
+			GPSSpeedRef:             vipsExifStringTag(it.image, GPSSpeedRef),
+			GPSSpeed:                vipsExifStringTag(it.image, GPSSpeed),
+			GPSImgDirectionRef:      vipsExifStringTag(it.image, GPSImgDirectionRef),
+			GPSImgDirection:         vipsExifStringTag(it.image, GPSImgDirection),
+			GPSDestBearingRef:       vipsExifStringTag(it.image, GPSDestBearingRef),
+			GPSDestBearing:          vipsExifStringTag(it.image, GPSDestBearing),
+			GPSDateStamp:            vipsExifStringTag(it.image, GPSDateStamp),
+		},
+	}
+}
+
 // TODO convert o.SmartCrop to o.Gravity

--- a/transformation.go
+++ b/transformation.go
@@ -1,0 +1,46 @@
+package bimg
+
+import "C"
+import "runtime"
+
+type ImageTransformation struct {
+	image     *C.VipsImage
+	imageType ImageType
+}
+
+func NewImageTransformation(buf []byte) (*ImageTransformation, error) {
+	image, imageType, err := vipsRead(buf)
+	if err != nil {
+		return nil, err
+	}
+	it := &ImageTransformation{
+		image:     image,
+		imageType: imageType,
+	}
+	runtime.SetFinalizer(it, finalizeImageTransformation)
+	return it, nil
+}
+
+func (it *ImageTransformation) Clone() *ImageTransformation {
+	clone := &ImageTransformation{
+		image:     it.image,
+		imageType: it.imageType,
+	}
+	C.g_object_ref(C.gpointer(clone.image))
+	runtime.SetFinalizer(it, finalizeImageTransformation)
+	return clone
+}
+
+func (it *ImageTransformation) Close() {
+	C.g_object_unref(C.gpointer(it.image))
+	it.image = nil
+}
+
+func finalizeImageTransformation(it *ImageTransformation) {
+	it.Close()
+}
+
+func (it *ImageTransformation) updateImage(image *C.VipsImage) {
+	C.g_object_unref(C.gpointer(it.image))
+	it.image = image
+}

--- a/transformation.go
+++ b/transformation.go
@@ -345,7 +345,14 @@ func (it *ImageTransformation) WatermarkText(opts Watermark) error {
 	}
 }
 
-func (it *ImageTransformation) WatermarkImage(opts WatermarkImage) error {
+type WatermarkImageOptions struct {
+	Left    int
+	Top     int
+	Image   *ImageTransformation
+	Opacity float32
+}
+
+func (it *ImageTransformation) WatermarkImage(opts WatermarkImageOptions) error {
 	if image, err := watermarkImageWithAnotherImage(it.image, opts); err != nil {
 		return err
 	} else {

--- a/transformation_test.go
+++ b/transformation_test.go
@@ -1,0 +1,106 @@
+package bimg
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestImageTransformation_Resize(t *testing.T) {
+	tests := []struct {
+		mode     ResizeMode
+		width    int
+		height   int
+		expected ImageSize
+	}{
+		{
+			mode:     ResizeModeFit,
+			width:    400,
+			height:   300,
+			expected: ImageSize{400, 250},
+		},
+		{
+			mode:     ResizeModeFit,
+			width:    300,
+			height:   400,
+			expected: ImageSize{300, 187},
+		},
+		{
+			mode:     ResizeModeFit,
+			width:    800,
+			height:   400,
+			expected: ImageSize{640, 400},
+		},
+		{
+			mode:     ResizeModeFitUp,
+			width:    400,
+			height:   300,
+			expected: ImageSize{480, 300},
+		},
+		{
+			mode:     ResizeModeFitUp,
+			width:    300,
+			height:   400,
+			expected: ImageSize{640, 400},
+		},
+		{
+			mode:     ResizeModeFitUp,
+			width:    800,
+			height:   400,
+			expected: ImageSize{800, 500},
+		},
+		{
+			mode:     ResizeModeForce,
+			width:    400,
+			height:   300,
+			expected: ImageSize{400, 300},
+		},
+		{
+			mode:     ResizeModeForce,
+			width:    300,
+			height:   400,
+			expected: ImageSize{300, 400},
+		},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("%s_%d_%d", test.mode, test.width, test.height)
+		t.Run(name, func(t *testing.T) {
+			imageTrans, err := NewImageTransformation(readImage("test.jpg"))
+			if err != nil {
+				t.Fatalf("cannot load image: %v", err)
+			}
+			if err := imageTrans.Resize(ResizeOptions{Width: test.width, Height: test.height, Mode: test.mode}); err != nil {
+				t.Fatalf("cannot resize image: %v", err)
+			}
+			size := imageTrans.Size()
+			if size != test.expected {
+				t.Errorf("unexpected size. wanted %#v, got %#v", test.expected, size)
+			}
+			if out, err := imageTrans.Save(SaveOptions{Type: JPEG}); err != nil {
+				t.Errorf("cannot save image: %v", err)
+			} else {
+				Write(fmt.Sprintf("testdata/transformation_resize_%s_out.jpeg", name), out)
+			}
+		})
+	}
+
+	t.Run("upscale", func(t *testing.T) {
+		imageTrans, err := NewImageTransformation(readImage("test.webp"))
+		if err != nil {
+			t.Fatalf("cannot load image: %v", err)
+		}
+		if err := imageTrans.Resize(ResizeOptions{Width: 2000, Height: 2000}); err != nil {
+			t.Fatalf("cannot resize image: %v", err)
+		}
+		size := imageTrans.Size()
+		expected := ImageSize{2000, 1338}
+		if size != expected {
+			t.Errorf("unexpected size. wanted %#v, got %#v", expected, size)
+		}
+		if out, err := imageTrans.Save(SaveOptions{Type: JPEG}); err != nil {
+			t.Errorf("cannot save image: %v", err)
+		} else {
+			Write("testdata/transformation_resize_upscale_out.jpeg", out)
+		}
+	})
+}

--- a/type_test.go
+++ b/type_test.go
@@ -25,16 +25,18 @@ func TestDeterminateImageType(t *testing.T) {
 	}
 
 	for _, file := range files {
-		img, _ := os.Open(path.Join("testdata", file.name))
-		buf, _ := ioutil.ReadAll(img)
-		defer img.Close()
+		t.Run(file.name, func(t *testing.T) {
+			img, _ := os.Open(path.Join("testdata", file.name))
+			buf, _ := ioutil.ReadAll(img)
+			defer img.Close()
 
-		if VipsIsTypeSupported(file.expected) {
-			value := DetermineImageType(buf)
-			if value != file.expected {
-				t.Fatalf("Image type is not valid: %s != %s, got: %s", file.name, ImageTypes[file.expected], ImageTypes[value])
+			if VipsIsTypeSupported(file.expected) {
+				value := DetermineImageType(buf)
+				if value != file.expected {
+					t.Fatalf("Image type is not valid: wanted %s, got: %s", ImageTypes[file.expected], ImageTypes[value])
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -139,13 +139,15 @@ func TestIsTypeNameSupportedSave(t *testing.T) {
 		{"webp", true},
 		{"gif", false},
 		{"pdf", false},
-		{"tiff", VipsVersion >= "8.5.0"},
-		{"heif", VipsVersion >= "8.8.0"},
+		{"tiff", VipsMajorVersion >= 8 && VipsMinorVersion >= 5},
+		{"heif", VipsMajorVersion >= 8 && VipsMinorVersion >= 8},
 	}
 
 	for _, n := range types {
-		if IsTypeNameSupportedSave(n.name) != n.expected {
-			t.Fatalf("Image type %s is not valid", n.name)
-		}
+		t.Run(n.name, func(t *testing.T) {
+			if IsTypeNameSupportedSave(n.name) != n.expected {
+				t.Fatalf("Image type is not valid (expected = %t)", n.expected)
+			}
+		})
 	}
 }

--- a/type_test.go
+++ b/type_test.go
@@ -40,72 +40,84 @@ func TestDeterminateImageType(t *testing.T) {
 
 func TestDeterminateImageTypeName(t *testing.T) {
 	files := []struct {
-		name     string
-		expected string
+		name      string
+		expected  string
+		condition bool
 	}{
-		{"test.jpg", "jpeg"},
-		{"test.png", "png"},
-		{"test.webp", "webp"},
-		{"test.gif", "gif"},
-		{"test.pdf", "pdf"},
-		{"test.svg", "svg"},
+		{"test.jpg", "jpeg", true},
+		{"test.png", "png", true},
+		{"test.webp", "webp", true},
+		{"test.gif", "gif", true},
+		{"test.pdf", "pdf", true},
+		{"test.svg", "svg", true},
 		// {"test.jp2", "magick"},
-		{"test.heic", "heif"},
+		{"test.heic", "heif", vipsVersionMin(8, 8)},
 	}
 
 	for _, file := range files {
-		if file.expected == "heif" && VipsMajorVersion <= 8 && VipsMinorVersion < 8 {
-			continue
-		}
+		t.Run(file.name, func(t *testing.T) {
+			if !file.condition {
+				t.Skip("condition not met")
+			}
 
-		img, _ := os.Open(path.Join("testdata", file.name))
-		buf, _ := ioutil.ReadAll(img)
-		defer img.Close()
+			img, _ := os.Open(path.Join("testdata", file.name))
+			buf, _ := ioutil.ReadAll(img)
+			defer img.Close()
 
-		value := DetermineImageTypeName(buf)
-		if value != file.expected {
-			t.Fatalf("Image type is not valid: %s != %s, got: %s", file.name, file.expected, value)
-		}
+			value := DetermineImageTypeName(buf)
+			if value != file.expected {
+				t.Fatalf("Image type is not valid: %s != %s, got: %s", file.name, file.expected, value)
+			}
+		})
+
 	}
 }
 
 func TestIsTypeSupported(t *testing.T) {
 	types := []struct {
-		name ImageType
+		name      ImageType
+		supported bool
 	}{
-		{JPEG}, {PNG}, {WEBP}, {GIF}, {PDF}, {HEIF},
+		{JPEG, true},
+		{PNG, true},
+		{WEBP, true},
+		{GIF, true},
+		{PDF, true},
+		{HEIF, vipsVersionMin(8, 8)},
 	}
 
-	for _, n := range types {
-		if n.name == HEIF && VipsMajorVersion <= 8 && VipsMinorVersion < 8 {
-			continue
-		}
-		if IsTypeSupported(n.name) == false {
-			t.Fatalf("Image type %s is not valid", ImageTypes[n.name])
-		}
+	for _, typ := range types {
+		t.Run(ImageTypes[typ.name], func(t *testing.T) {
+			if IsTypeSupported(typ.name) != typ.supported {
+				t.Fatalf("Image type support is not as expected")
+			}
+		})
 	}
 }
 
 func TestIsTypeNameSupported(t *testing.T) {
 	types := []struct {
-		name     string
-		expected bool
+		name      string
+		expected  bool
+		condition bool
 	}{
-		{"jpeg", true},
-		{"png", true},
-		{"webp", true},
-		{"gif", true},
-		{"pdf", true},
-		{"heif", true},
+		{"jpeg", true, true},
+		{"png", true, true},
+		{"webp", true, true},
+		{"gif", true, true},
+		{"pdf", true, true},
+		{"heif", true, vipsVersionMin(8, 8)},
 	}
 
 	for _, n := range types {
-		if n.name == "heif" && VipsMajorVersion <= 8 && VipsMinorVersion < 8 {
-			continue
-		}
-		if IsTypeNameSupported(n.name) != n.expected {
-			t.Fatalf("Image type %s is not valid", n.name)
-		}
+		t.Run(n.name, func(t *testing.T) {
+			if !n.condition {
+				t.Skip("condition not met")
+			}
+			if IsTypeNameSupported(n.name) != n.expected {
+				t.Fatalf("Image type %s is not valid", n.name)
+			}
+		})
 	}
 }
 
@@ -115,10 +127,10 @@ func TestIsTypeSupportedSave(t *testing.T) {
 	}{
 		{JPEG}, {PNG}, {WEBP},
 	}
-	if VipsVersion >= "8.5.0" {
+	if vipsVersionMin(8, 5) {
 		types = append(types, struct{ name ImageType }{TIFF})
 	}
-	if VipsVersion >= "8.8.0" {
+	if vipsVersionMin(8, 8) {
 		types = append(types, struct{ name ImageType }{HEIF})
 	}
 
@@ -139,8 +151,8 @@ func TestIsTypeNameSupportedSave(t *testing.T) {
 		{"webp", true},
 		{"gif", false},
 		{"pdf", false},
-		{"tiff", VipsMajorVersion >= 8 && VipsMinorVersion >= 5},
-		{"heif", VipsMajorVersion >= 8 && VipsMinorVersion >= 8},
+		{"tiff", vipsVersionMin(8, 5)},
+		{"heif", vipsVersionMin(8, 8)},
 	}
 
 	for _, n := range types {

--- a/type_test.go
+++ b/type_test.go
@@ -151,7 +151,7 @@ func TestIsTypeNameSupportedSave(t *testing.T) {
 		{"jpeg", true},
 		{"png", true},
 		{"webp", true},
-		{"gif", false},
+		{"gif", vipsVersionMin(8, 0)},
 		{"pdf", false},
 		{"tiff", vipsVersionMin(8, 5)},
 		{"heif", vipsVersionMin(8, 8)},

--- a/vips.go
+++ b/vips.go
@@ -64,7 +64,7 @@ type vipsWatermarkOptions struct {
 	Margin      C.int
 	NoReplicate C.int
 	Opacity     C.float
-	Background  [3]C.double
+	Background  interface{}
 }
 
 type vipsWatermarkImageOptions struct {
@@ -328,7 +328,19 @@ func vipsWatermark(image *C.VipsImage, w Watermark) (*C.VipsImage, error) {
 
 	text := C.CString(w.Text)
 	font := C.CString(w.Font)
-	background := [3]C.double{C.double(w.Background.R), C.double(w.Background.G), C.double(w.Background.B)}
+
+	var r, g, b uint8
+	var a uint8 = 0xFF
+	if w.Background != nil {
+		r, g, b, a = w.Background.RGBA()
+	}
+
+	var background interface{}
+	if vipsHasAlpha(image) {
+		background = [4]C.double{C.double(r), C.double(g), C.double(b), C.double(a)}
+	} else {
+		background = [3]C.double{C.double(r), C.double(g), C.double(b)}
+	}
 
 	textOpts := vipsWatermarkTextOptions{text, font}
 	opts := vipsWatermarkOptions{C.int(w.Width), C.int(w.DPI), C.int(w.Margin), C.int(noReplicate), C.float(w.Opacity), background}

--- a/vips.go
+++ b/vips.go
@@ -649,7 +649,7 @@ func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, 
 
 	defer C.g_object_unref(C.gpointer(input))
 	err := C.vips_embed_bridge(input, &image, C.int(left), C.int(top), C.int(width),
-		C.int(height), C.int(extend), C.double(background.R), C.double(background.G), C.double(background.B))
+		C.int(height), C.int(extend), C.double(background.R), C.double(background.G), C.double(background.B), C.double(background.A))
 	if err != 0 {
 		return nil, catchVipsError()
 	}

--- a/vips.go
+++ b/vips.go
@@ -86,7 +86,7 @@ func init() {
 	Initialize()
 }
 
-func newVipsImage(cImage *C.VipsImage) *vipsImage {
+func wrapVipsImage(cImage *C.VipsImage) *vipsImage {
 	vipsImage := &vipsImage{cImage}
 	runtime.SetFinalizer(vipsImage, finalizeVipsImage)
 	return vipsImage
@@ -98,7 +98,7 @@ func (vi *vipsImage) isNil() bool {
 
 func (vi *vipsImage) clone() *vipsImage {
 	C.g_object_ref(C.gpointer(vi.c))
-	return newVipsImage(vi.c)
+	return wrapVipsImage(vi.c)
 }
 
 func (vi *vipsImage) close() {
@@ -290,7 +290,7 @@ func vipsRotate(image *vipsImage, angle Angle) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsAutoRotate(image *vipsImage) (*vipsImage, error) {
@@ -301,7 +301,7 @@ func vipsAutoRotate(image *vipsImage) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsTransformICC(image *vipsImage, inputICC string, outputICC string) (*vipsImage, error) {
@@ -317,7 +317,7 @@ func vipsTransformICC(image *vipsImage, inputICC string, outputICC string) (*vip
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsFlip(image *vipsImage, direction Direction) (*vipsImage, error) {
@@ -328,7 +328,7 @@ func vipsFlip(image *vipsImage, direction Direction) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsZoom(image *vipsImage, zoom int) (*vipsImage, error) {
@@ -339,7 +339,7 @@ func vipsZoom(image *vipsImage, zoom int) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsWatermark(image *vipsImage, w Watermark) (*vipsImage, error) {
@@ -378,7 +378,7 @@ func vipsWatermark(image *vipsImage, w Watermark) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsRead(buf []byte) (*vipsImage, ImageType, error) {
@@ -397,7 +397,7 @@ func vipsRead(buf []byte) (*vipsImage, ImageType, error) {
 		return nil, UNKNOWN, catchVipsError()
 	}
 
-	return newVipsImage(image), imageType, nil
+	return wrapVipsImage(image), imageType, nil
 }
 
 func vipsColourspaceIsSupportedBuffer(buf []byte) (bool, error) {
@@ -405,7 +405,6 @@ func vipsColourspaceIsSupportedBuffer(buf []byte) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	C.g_object_unref(C.gpointer(image))
 	return vipsColourspaceIsSupported(image), nil
 }
 
@@ -418,7 +417,6 @@ func vipsInterpretationBuffer(buf []byte) (Interpretation, error) {
 	if err != nil {
 		return InterpretationError, err
 	}
-	C.g_object_unref(C.gpointer(image))
 	return vipsInterpretation(image), nil
 }
 
@@ -448,7 +446,7 @@ func vipsFlattenBackground(image *vipsImage, background RGBAProvider) (*vipsImag
 	if int(err) != 0 {
 		return nil, catchVipsError()
 	}
-	return newVipsImage(outImage), nil
+	return wrapVipsImage(outImage), nil
 }
 
 func vipsPreSave(image *vipsImage, o *vipsSaveOptions) (*vipsImage, error) {
@@ -470,7 +468,7 @@ func vipsPreSave(image *vipsImage, o *vipsSaveOptions) (*vipsImage, error) {
 		if int(err) != 0 {
 			return nil, catchVipsError()
 		}
-		image = newVipsImage(outImage)
+		image = wrapVipsImage(outImage)
 	}
 
 	if o.OutputICC != "" && o.InputICC != "" {
@@ -484,7 +482,7 @@ func vipsPreSave(image *vipsImage, o *vipsSaveOptions) (*vipsImage, error) {
 		if int(err) != 0 {
 			return nil, catchVipsError()
 		}
-		return newVipsImage(outImage), nil
+		return wrapVipsImage(outImage), nil
 	}
 
 	if o.OutputICC != "" && vipsHasProfile(image) {
@@ -495,7 +493,7 @@ func vipsPreSave(image *vipsImage, o *vipsSaveOptions) (*vipsImage, error) {
 		if int(err) != 0 {
 			return nil, catchVipsError()
 		}
-		image = newVipsImage(outImage)
+		image = wrapVipsImage(outImage)
 	}
 
 	return image, nil
@@ -599,7 +597,7 @@ func vipsExtract(image *vipsImage, left, top, width, height int) (*vipsImage, er
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsSmartCrop(image *vipsImage, width, height int) (*vipsImage, error) {
@@ -614,7 +612,7 @@ func vipsSmartCrop(image *vipsImage, width, height int) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsTrim(image *vipsImage, background RGBAProvider, threshold float64) (int, int, int, int, error) {
@@ -650,7 +648,7 @@ func vipsShrinkJpeg(buf []byte, shrink int) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsShrinkWebp(buf []byte, shrink int) (*vipsImage, error) {
@@ -662,7 +660,7 @@ func vipsShrinkWebp(buf []byte, shrink int) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsShrink(input *vipsImage, shrink int) (*vipsImage, error) {
@@ -673,7 +671,7 @@ func vipsShrink(input *vipsImage, shrink int) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsReduce(input *vipsImage, xshrink float64, yshrink float64) (*vipsImage, error) {
@@ -684,7 +682,7 @@ func vipsReduce(input *vipsImage, xshrink float64, yshrink float64) (*vipsImage,
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsEmbed(input *vipsImage, left, top, width, height int, extend Extend, background RGBAProvider) (*vipsImage, error) {
@@ -710,7 +708,7 @@ func vipsEmbed(input *vipsImage, left, top, width, height int, extend Extend, ba
 			// No alpha channel but the background color is not opaque? Try to add an alpha channel then.
 			var withAlpha *C.VipsImage = C.vips_image_new()
 			C.vips_addalpha_bridge(input.c, &withAlpha)
-			input = newVipsImage(withAlpha)
+			input = wrapVipsImage(withAlpha)
 		}
 
 		if hasAlpha || a < 0xFF {
@@ -728,7 +726,7 @@ func vipsEmbed(input *vipsImage, left, top, width, height int, extend Extend, ba
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsAffine(input *vipsImage, residualx, residualy float64, i Interpolator, extend Extend) (*vipsImage, error) {
@@ -748,7 +746,7 @@ func vipsAffine(input *vipsImage, residualx, residualy float64, i Interpolator, 
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(image), nil
+	return wrapVipsImage(image), nil
 }
 
 func vipsImageType(buf []byte) ImageType {
@@ -840,7 +838,7 @@ func vipsGaussianBlur(image *vipsImage, o GaussianBlur) (*vipsImage, error) {
 	if err != 0 {
 		return nil, catchVipsError()
 	}
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsSharpen(image *vipsImage, o Sharpen) (*vipsImage, error) {
@@ -850,7 +848,7 @@ func vipsSharpen(image *vipsImage, o Sharpen) (*vipsImage, error) {
 	if err != 0 {
 		return nil, catchVipsError()
 	}
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func max(x int) int {
@@ -874,7 +872,7 @@ func vipsDrawWatermark(image *vipsImage, o WatermarkImage) (*vipsImage, error) {
 		return nil, catchVipsError()
 	}
 
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }
 
 func vipsGamma(image *vipsImage, Gamma float64) (*vipsImage, error) {
@@ -884,5 +882,5 @@ func vipsGamma(image *vipsImage, Gamma float64) (*vipsImage, error) {
 	if err != 0 {
 		return nil, catchVipsError()
 	}
-	return newVipsImage(out), nil
+	return wrapVipsImage(out), nil
 }

--- a/vips.go
+++ b/vips.go
@@ -198,56 +198,50 @@ func VipsMemory() VipsMemoryInfo {
 // VipsIsTypeSupported returns true if the given image type
 // is supported by the current libvips compilation.
 func VipsIsTypeSupported(t ImageType) bool {
-	if t == JPEG {
+	switch t {
+	case JPEG:
 		return int(C.vips_type_find_bridge(C.JPEG)) != 0
-	}
-	if t == WEBP {
+	case WEBP:
 		return int(C.vips_type_find_bridge(C.WEBP)) != 0
-	}
-	if t == PNG {
+	case PNG:
 		return int(C.vips_type_find_bridge(C.PNG)) != 0
-	}
-	if t == GIF {
+	case GIF:
 		return int(C.vips_type_find_bridge(C.GIF)) != 0
-	}
-	if t == PDF {
+	case PDF:
 		return int(C.vips_type_find_bridge(C.PDF)) != 0
-	}
-	if t == SVG {
+	case SVG:
 		return int(C.vips_type_find_bridge(C.SVG)) != 0
-	}
-	if t == TIFF {
+	case TIFF:
 		return int(C.vips_type_find_bridge(C.TIFF)) != 0
-	}
-	if t == MAGICK {
+	case MAGICK:
 		return int(C.vips_type_find_bridge(C.MAGICK)) != 0
-	}
-	if t == HEIF {
+	case HEIF:
 		return int(C.vips_type_find_bridge(C.HEIF)) != 0
+	default:
+		return false
 	}
-	return false
 }
 
 // VipsIsTypeSupportedSave returns true if the given image type
 // is supported by the current libvips compilation for the
 // save operation.
 func VipsIsTypeSupportedSave(t ImageType) bool {
-	if t == JPEG {
+	switch t {
+	case JPEG:
 		return int(C.vips_type_find_save_bridge(C.JPEG)) != 0
-	}
-	if t == WEBP {
+	case WEBP:
 		return int(C.vips_type_find_save_bridge(C.WEBP)) != 0
-	}
-	if t == PNG {
+	case PNG:
 		return int(C.vips_type_find_save_bridge(C.PNG)) != 0
-	}
-	if t == TIFF {
+	case TIFF:
 		return int(C.vips_type_find_save_bridge(C.TIFF)) != 0
-	}
-	if t == HEIF {
+	case HEIF:
 		return int(C.vips_type_find_save_bridge(C.HEIF)) != 0
+	case GIF:
+		return int(C.vips_type_find_save_bridge(C.GIF)) != 0
+	default:
+		return false
 	}
-	return false
 }
 
 func vipsExifStringTag(image *vipsImage, tag string) string {
@@ -526,6 +520,10 @@ func vipsSave(image *vipsImage, o vipsSaveOptions) ([]byte, error) {
 		saveErr = C.vips_tiffsave_bridge(image.c, &ptr, &length)
 	case HEIF:
 		saveErr = C.vips_heifsave_bridge(image.c, &ptr, &length, strip, quality, lossless)
+	case GIF:
+		formatString := C.CString("GIF")
+		defer C.free(unsafe.Pointer(formatString))
+		saveErr = C.vips_magicksave_bridge(image.c, &ptr, &length, formatString, quality)
 	default:
 		saveErr = C.vips_jpegsave_bridge(image.c, &ptr, &length, strip, quality, interlace)
 	}

--- a/vips.go
+++ b/vips.go
@@ -68,7 +68,7 @@ type vipsWatermarkOptions struct {
 	Margin      C.int
 	NoReplicate C.int
 	Opacity     C.float
-	Background  interface{}
+	Background  [3]C.double
 }
 
 type vipsWatermarkImageOptions struct {
@@ -355,17 +355,12 @@ func vipsWatermark(image *vipsImage, w Watermark) (*vipsImage, error) {
 	font := C.CString(w.Font)
 
 	var r, g, b uint8
-	var a uint8 = 0xFF
 	if w.Background != nil {
-		r, g, b, a = w.Background.RGBA()
+		r, g, b, _ = w.Background.RGBA()
 	}
 
-	var background interface{}
-	if vipsHasAlpha(image) {
-		background = [4]C.double{C.double(r), C.double(g), C.double(b), C.double(a)}
-	} else {
-		background = [3]C.double{C.double(r), C.double(g), C.double(b)}
-	}
+	var background [3]C.double
+	background = [3]C.double{C.double(r), C.double(g), C.double(b)}
 
 	textOpts := vipsWatermarkTextOptions{text, font}
 	opts := vipsWatermarkOptions{C.int(w.Width), C.int(w.DPI), C.int(w.Margin), C.int(noReplicate), C.float(w.Opacity), background}

--- a/vips.go
+++ b/vips.go
@@ -839,18 +839,19 @@ func max(x int) int {
 	return int(math.Max(float64(x), 0))
 }
 
-func vipsDrawWatermark(image *vipsImage, o WatermarkImage) (*vipsImage, error) {
-	var out *C.VipsImage
+type drawWatermarkOptions struct {
+	Left    int
+	Top     int
+	Image   *vipsImage
+	Opacity float32
+}
 
-	// TODO vipsImage instead?
-	watermark, _, e := vipsRead(o.Buf)
-	if e != nil {
-		return nil, e
-	}
+func vipsDrawWatermark(image *vipsImage, o drawWatermarkOptions) (*vipsImage, error) {
+	var out *C.VipsImage
 
 	opts := vipsWatermarkImageOptions{C.int(o.Left), C.int(o.Top), C.float(o.Opacity)}
 
-	err := C.vips_watermark_image(image.c, watermark.c, &out, (*C.WatermarkImageOptions)(unsafe.Pointer(&opts)))
+	err := C.vips_watermark_image(image.c, o.Image.c, &out, (*C.WatermarkImageOptions)(unsafe.Pointer(&opts)))
 
 	if err != 0 {
 		return nil, catchVipsError()

--- a/vips.go
+++ b/vips.go
@@ -112,6 +112,10 @@ func finalizeVipsImage(vi *vipsImage) {
 	vi.close()
 }
 
+func vipsVersionMin(major, minor int) bool {
+	return VipsMajorVersion > major || (VipsMajorVersion == major && VipsMinorVersion >= minor)
+}
+
 // Initialize is used to explicitly start libvips in thread-safe way.
 // Only call this function if you have previously turned off libvips.
 func Initialize() {
@@ -381,7 +385,7 @@ func vipsRead(buf []byte) (*vipsImage, ImageType, error) {
 	imageType := vipsImageType(buf)
 
 	if imageType == UNKNOWN {
-		return nil, UNKNOWN, errors.New("Unsupported image format")
+		return nil, UNKNOWN, errors.New("unsupported image format")
 	}
 
 	length := C.size_t(len(buf))
@@ -583,7 +587,7 @@ func vipsExtract(image *vipsImage, left, top, width, height int) (*vipsImage, er
 	var out *C.VipsImage
 
 	if width > MaxSize || height > MaxSize {
-		return nil, errors.New("Maximum image size exceeded")
+		return nil, errors.New("maximum image size exceeded")
 	}
 
 	top, left = max(top), max(left)

--- a/vips.h
+++ b/vips.h
@@ -327,7 +327,7 @@ vips_jpegsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 
 int
 vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compression, int quality, int interlace, int palette) {
-#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 7)
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 7))
 	return vips_pngsave_buffer(in, buf, len,
 		"strip", INT_TO_GBOOLEAN(strip),
 		"compression", compression,
@@ -358,7 +358,7 @@ vips_webpsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 
 int
 vips_tiffsave_bridge(VipsImage *in, void **buf, size_t *len) {
-#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 5)
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 5))
 	return vips_tiffsave_buffer(in, buf, len, NULL);
 #else
 	return 0;
@@ -543,7 +543,7 @@ vips_sharpen_bridge(VipsImage *in, VipsImage **out, int radius, double x1, doubl
 
 int
 vips_add_band(VipsImage *in, VipsImage **out, double c) {
-#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 2))
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 2))
 	return vips_bandjoin_const1(in, out, c, NULL);
 #else
 	VipsImage *base = vips_image_new();
@@ -611,7 +611,7 @@ vips_watermark_image(VipsImage *in, VipsImage *sub, VipsImage **out, WatermarkIm
 
 int
 vips_smartcrop_bridge(VipsImage *in, VipsImage **out, int width, int height) {
-#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 5)
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 5))
 	return vips_smartcrop(in, out, width, height, NULL);
 #else
 	return 0;
@@ -619,7 +619,7 @@ vips_smartcrop_bridge(VipsImage *in, VipsImage **out, int width, int height) {
 }
 
 int vips_find_trim_bridge(VipsImage *in, int *top, int *left, int *width, int *height, double r, double g, double b, double threshold) {
-#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 6)
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 6))
 	if (vips_is_16bit(in->Type)) {
 		r = 65535 * r / 255;
 		g = 65535 * g / 255;

--- a/vips.h
+++ b/vips.h
@@ -269,16 +269,30 @@ vips_zoom_bridge(VipsImage *in, VipsImage **out, int xfac, int yfac) {
 }
 
 int
-vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b) {
+vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b, double a) {
 	if (extend == VIPS_EXTEND_BACKGROUND) {
-	if (has_alpha_channel(in) == 1) {
-		double background[4] = {r, g, b, 0.0};
-  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
-  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
-	} else {
-		double background[3] = {r, g, b};
-  	VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
-  	return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);}
+		int hasAlpha = has_alpha_channel(in);
+		
+		// We don't have an alpha channel but request alpha to be present? Add a channel then.
+		if (hasAlpha == 0 && a < 255.0) {
+			VipsImage *withAlpha = vips_image_new();
+			vips_addalpha(in, &withAlpha);
+			double background[4] = {r, g, b, a};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
+			int result = vips_embed(withAlpha, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+			g_object_unref(withAlpha);
+			return result;
+		}
+
+		if (hasAlpha == 1) {
+			double background[4] = {r, g, b, a};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
+			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+		} else {
+			double background[3] = {r, g, b};
+			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
+			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
+		}
 	}
 	return vips_embed(in, out, left, top, width, height, "extend", extend, NULL);
 }
@@ -335,7 +349,7 @@ vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compr
 		"compression", compression,
 		"interlace", INT_TO_GBOOLEAN(interlace),
 		"filter", VIPS_FOREIGN_PNG_FILTER_ALL,
-	        "palette", INT_TO_GBOOLEAN(palette),
+		"palette", INT_TO_GBOOLEAN(palette),
 		NULL
 	);
 #else

--- a/vips.h
+++ b/vips.h
@@ -269,30 +269,9 @@ vips_zoom_bridge(VipsImage *in, VipsImage **out, int xfac, int yfac) {
 }
 
 int
-vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, double r, double g, double b, double a) {
+vips_embed_bridge(VipsImage *in, VipsImage **out, int left, int top, int width, int height, int extend, VipsArrayDouble *background) {
 	if (extend == VIPS_EXTEND_BACKGROUND) {
-		int hasAlpha = has_alpha_channel(in);
-		
-		// We don't have an alpha channel but request alpha to be present? Add a channel then.
-		if (hasAlpha == 0 && a < 255.0) {
-			VipsImage *withAlpha = vips_image_new();
-			vips_addalpha(in, &withAlpha);
-			double background[4] = {r, g, b, a};
-			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
-			int result = vips_embed(withAlpha, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
-			g_object_unref(withAlpha);
-			return result;
-		}
-
-		if (hasAlpha == 1) {
-			double background[4] = {r, g, b, a};
-			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 4);
-			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
-		} else {
-			double background[3] = {r, g, b};
-			VipsArrayDouble *vipsBackground = vips_array_double_new(background, 3);
-			return vips_embed(in, out, left, top, width, height, "extend", extend, "background", vipsBackground, NULL);
-		}
+		return vips_embed(in, out, left, top, width, height, "extend", extend, "background", background, NULL);
 	}
 	return vips_embed(in, out, left, top, width, height, "extend", extend, NULL);
 }
@@ -637,7 +616,10 @@ int vips_find_trim_bridge(VipsImage *in, int *top, int *left, int *width, int *h
 #endif
 }
 
-int vips_gamma_bridge(VipsImage *in, VipsImage **out, double exponent)
-{
-  return vips_gamma(in, out, "exponent", 1.0 / exponent, NULL);
+int vips_gamma_bridge(VipsImage *in, VipsImage **out, double exponent) {
+	return vips_gamma(in, out, "exponent", 1.0 / exponent, NULL);
+}
+
+int vips_addalpha_bridge(VipsImage *in, VipsImage **out) {
+	return vips_addalpha(in, out);
 }

--- a/vips.h
+++ b/vips.h
@@ -184,6 +184,11 @@ vips_type_find_save_bridge(int t) {
 		return vips_type_find("VipsOperation", "heifsave_buffer");
 	}
 #endif
+#if (VIPS_MAJOR_VERSION >= 8)
+	if (t == GIF) {
+		return vips_type_find("VipsOperation", "magicksave_buffer");
+	}
+#endif
 	return 0;
 }
 
@@ -375,6 +380,19 @@ vips_heifsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 }
 
 int
+vips_magicksave_bridge(VipsImage *in, void **buf, size_t *len, const char *format, int quality) {
+#if (VIPS_MAJOR_VERSION >= 8)
+	return vips_magicksave_buffer(in, buf, len,
+		"format", format,
+		"quality", quality,
+		NULL
+	);
+#else
+	return 0;
+#endif
+}
+
+int
 vips_is_16bit (VipsInterpretation interpretation) {
 	return interpretation == VIPS_INTERPRETATION_RGB16 || interpretation == VIPS_INTERPRETATION_GREY16;
 }
@@ -410,7 +428,7 @@ vips_init_image (void *buf, size_t len, int imageType, VipsImage **out) {
 	} else if (imageType == TIFF) {
 		code = vips_tiffload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 #if (VIPS_MAJOR_VERSION >= 8)
-#if (VIPS_MINOR_VERSION >= 3)
+#if (VIPS_MAJOR_VERSION > 8 || VIPS_MINOR_VERSION >= 3)
 	} else if (imageType == GIF) {
 		code = vips_gifload_buffer(buf, len, out, "access", VIPS_ACCESS_RANDOM, NULL);
 	} else if (imageType == PDF) {

--- a/vips_test.go
+++ b/vips_test.go
@@ -89,8 +89,8 @@ func TestVipsAutoRotate(t *testing.T) {
 	}
 
 	files := []struct {
-		name         string
-		orientation  int
+		name        string
+		orientation int
 	}{
 		{"test.jpg", 0},
 		{"test_exif.jpg", 0},
@@ -165,10 +165,9 @@ func TestVipsWatermark(t *testing.T) {
 
 func TestVipsWatermarkWithImage(t *testing.T) {
 	image, _, _ := vipsRead(readImage("test.jpg"))
+	watermark, _, _ := vipsRead(readImage("transparent.png"))
 
-	watermark := readImage("transparent.png")
-
-	options := WatermarkImage{Left: 100, Top: 100, Opacity: 1.0, Buf: watermark}
+	options := drawWatermarkOptions{Left: 100, Top: 100, Opacity: 1.0, Image: watermark}
 	newImg, err := vipsDrawWatermark(image, options)
 	if err != nil {
 		t.Errorf("Cannot add watermark: %s", err)

--- a/vips_test.go
+++ b/vips_test.go
@@ -147,7 +147,7 @@ func TestVipsWatermark(t *testing.T) {
 		Width:      200,
 		DPI:        100,
 		Margin:     100,
-		Background: Color{255, 255, 255},
+		Background: Color{255, 255, 255, 255},
 	}
 
 	newImg, err := vipsWatermark(image, watermark)

--- a/vips_test.go
+++ b/vips_test.go
@@ -147,7 +147,7 @@ func TestVipsWatermark(t *testing.T) {
 		Width:      200,
 		DPI:        100,
 		Margin:     100,
-		Background: Color{255, 255, 255, 255},
+		Background: Color{255, 255, 255},
 	}
 
 	newImg, err := vipsWatermark(image, watermark)

--- a/vips_test.go
+++ b/vips_test.go
@@ -104,22 +104,24 @@ func TestVipsAutoRotate(t *testing.T) {
 	}
 
 	for _, file := range files {
-		image, _, _ := vipsRead(readImage(file.name))
+		t.Run(file.name, func(t *testing.T) {
+			image, _, _ := vipsRead(readImage(file.name))
 
-		newImg, err := vipsAutoRotate(image)
-		if err != nil {
-			t.Fatal("Cannot auto rotate the image")
-		}
+			newImg, err := vipsAutoRotate(image)
+			if err != nil {
+				t.Fatal("Cannot auto rotate the image")
+			}
 
-		orientation := vipsExifOrientation(newImg)
-		if orientation != file.orientation {
-			t.Fatalf("Invalid image orientation: %d != %d", orientation, file.orientation)
-		}
+			orientation := vipsExifOrientation(newImg)
+			if orientation != file.orientation {
+				t.Fatalf("Invalid image orientation: %d != %d", orientation, file.orientation)
+			}
 
-		buf, _ := vipsSave(newImg, vipsSaveOptions{Quality: 95})
-		if len(buf) == 0 {
-			t.Fatal("Empty image")
-		}
+			buf, _ := vipsSave(newImg, vipsSaveOptions{Quality: 95})
+			if len(buf) == 0 {
+				t.Fatal("Empty image")
+			}
+		})
 	}
 }
 

--- a/vips_test.go
+++ b/vips_test.go
@@ -98,9 +98,9 @@ func TestVipsAutoRotate(t *testing.T) {
 		{"exif/Landscape_2.jpg", 0},
 		{"exif/Landscape_3.jpg", 0},
 		{"exif/Landscape_4.jpg", 0},
-		{"exif/Landscape_5.jpg", 5},
+		{"exif/Landscape_5.jpg", 0},
 		{"exif/Landscape_6.jpg", 0},
-		{"exif/Landscape_7.jpg", 7},
+		{"exif/Landscape_7.jpg", 0},
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
A discussed a while ago, I refactored **a lot** of *bimg* to allow for (mostly) lossless transformations and cleanup the interface while at it. I also tackled a few technical debts and possible bugs when I encountered them. This includes my RGBA support from PR #351.

Sorry for this HUGE PR. I think it's worth it, though.

The API of *bimg* is untouched. So everything that worked before, still works. Under the hood this uses a new API though, that is also exposed: `ImageTransformation`. Let's take the example from the documentation:

```go
// read the raw data
buffer, err := bimg.Read("image.jpg")
if err != nil {
  fmt.Fprintln(os.Stderr, err)
  return
}

// decode the image and prepare our transformation chain
it, err := bimg.NewImageTransformation(buffer)
if err != nil {
  fmt.Fprintln(os.Stderr, err)
  return
}

// crop the image to a specific width
err = it.Crop(bimg.CropOptions{Width: 300})
if err != nil {
  fmt.Fprintln(os.Stderr, err)
  return
}

// then flip it
err = it.Rotate(bimg.RotateOptions{Flip: true})
if err != nil {
  fmt.Fprintln(os.Stderr, err)
  return
}

// encode the image
newImage, err := it.Save(bimg.SaveOptions{})
if err != nil {
  fmt.Fprintln(os.Stderr, err)
  return
} 

// save the cropped and flipped image
bimg.Write("new.jpg", newImage)
```

After `NewImageTransformation` we now have a `VipsImage` under the hood, not a buffer. The operations `Crop`, `Rotate`, etc. now perform on this `VipsImage` (replacing it in the process). It will not be re-encoded in between. Only when calling `Save` will the image be encoded. Especially when dealing with lossy formats like JPEG, this significantly improves image quality, since it only encodes once (while before it would have encoded and then decoded the JPEG between these stages).

This, in short, is the main new feature of this PR.

---

### Additionally

* `VipsImage` is now ref counted and is registered with the garbage collector for cleanup. So when the Go GC removes the reference, it will also remove its Glib reference. We therefore don't have to cleanup after ourselves all the time (but we *can* call `Close()` to help the GC)
* I added support for saving GIF images (using `magicksave`).
* Background color arrays are now created on the Go side, not on the C side. This shortens the C code and keeps the business logic closer to where we expect it.
* A few VipsVersion checks were wrong and would break in the future. I fixed them.
* I replaced a few cascaded if-statements with switch-statements.
* Determining the filetype is now done using strings instead of sequences of bytes, to increase the readability.

---

### Possible Considerations

I think the `ImageTransformation` could as well replace the `Image` and its fluent interface. This would, however, break the API. If this is desired, we can certainly do that and release it as v2. I am also fine keeping it separate (and/or combine it later).