### PR TITLE
Panic on reading Exif

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -228,8 +228,9 @@ func vipsExifOrientation(image *C.VipsImage) int {
 }
 
 func vipsExifShort(s string) string {
-	if strings.Contains(s, " (") {
-		return s[:strings.Index(s, "(")-1]
+	i := strings.Index(s, " (")
+	if i > 0 {
+		return s[:i]
 	}
 	return s
 }

--- a/vips_test.go
+++ b/vips_test.go
@@ -89,8 +89,8 @@ func TestVipsAutoRotate(t *testing.T) {
 	}
 
 	files := []struct {
-		name         string
-		orientation  int
+		name        string
+		orientation int
 	}{
 		{"test.jpg", 0},
 		{"test_exif.jpg", 0},
@@ -200,6 +200,33 @@ func TestVipsMemory(t *testing.T) {
 	}
 	if mem.Allocations == 0 {
 		t.Fatal("Invalid memory allocations")
+	}
+}
+
+func TestVipsExifShort(t *testing.T) {
+	tt := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    `( ()`,
+			expected: `(`,
+		},
+		{
+			input:    ` ()`,
+			expected: ` ()`,
+		},
+		{
+			input:    `sRGB`,
+			expected: `sRGB`,
+		},
+	}
+
+	for _, tc := range tt {
+		got := vipsExifShort(tc.input)
+		if got != tc.expected {
+			t.Fatalf("expected: %s; got: %s", tc.expected, got)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR fixes runtime error  `slice bounds out of range [:-1]` when reading Exif metadata if Exif tag value contains " (" and starts with "(".
