### PR TITLE
unref the image *after* we used it

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -388,8 +388,9 @@ func vipsInterpretationBuffer(buf []byte) (Interpretation, error) {
 	if err != nil {
 		return InterpretationError, err
 	}
+	interp := vipsInterpretation(image)
 	C.g_object_unref(C.gpointer(image))
-	return vipsInterpretation(image), nil
+	return interp, nil
 }
 
 func vipsInterpretation(image *C.VipsImage) Interpretation {


### PR DESCRIPTION
Otherwise we manipulate potentially deallocated memory.
On some distributions things go fine for some reason, but
on others the memory actually gets deallocated and garbage is used,
leading to a segmentation fault in vips_image_guess_interpretation
