### PR TITLE
Fix for blurry images from WEBP input and small output dimensions

### DIFF
--- a/resizer.go
+++ b/resizer.go
@@ -69,7 +69,6 @@ func resizer(buf []byte, o Options) ([]byte, error) {
 	shrink := calculateShrink(factor, o.Interpolator)
 	residual := calculateResidual(factor, shrink)
 
-	fmt.Printf("size=%vx%v, factor=%v, shrink=%v, residual=%v, opts=%+v\n", inWidth, inHeight, factor, shrink, residual, o)
 	// Do not enlarge the output if the input width or height
 	// are already less than the required dimensions
 	if !o.Enlarge && !o.Force {


### PR DESCRIPTION
This will fix blurry images if the input is in webp format and the output is relativly small in his dimensions. This will fix issues #220, #339 makes #222 obsolet. This will also fix https://github.com/h2non/imaginary/issues/240.

The underlying issue is, that the `factor` comming out from `supportsShrinkOnLoad` is too high. `transformImage` has then a too large `shrink` and the image gets blurred.

I have no good idea, how to put that in a unit test, since the image output may differ on plattforms.

I did some manual testing with a lot of different output resolutions and compared the old with the new code. All blurring is gone.

`shrinkOnload` uses for WEBP now the same logic as for JPEG.