### PR TITLE
Add GIF save support from libvips 8.12

### DIFF
--- a/image_test.go
+++ b/image_test.go
@@ -21,9 +21,18 @@ func TestImageResize(t *testing.T) {
 }
 
 func TestImageGifResize(t *testing.T) {
-	_, err := initImage("test.gif").Resize(300, 240)
-	if err == nil {
-		t.Errorf("GIF shouldn't be saved within VIPS")
+	if VipsMajorVersion >= 8 && VipsMinorVersion >= 12 {
+		buf, err := initImage("test.gif").Resize(300, 240)
+		if err != nil {
+			t.Errorf("Cannot process the image: %#v", err)
+		}
+
+		err = assertSize(buf, 300, 240)
+		if err != nil {
+			t.Error(err)
+		}
+
+		Write("testdata/test_resize_out.gif", buf)
 	}
 }
 

--- a/type_test.go
+++ b/type_test.go
@@ -125,7 +125,7 @@ func TestIsTypeSupportedSave(t *testing.T) {
 	types := []struct {
 		name ImageType
 	}{
-		{JPEG}, {PNG}, {WEBP},
+		{JPEG}, {PNG}, {WEBP}, {GIF},
 	}
 	if VipsVersion >= "8.5.0" {
 		types = append(types, struct{ name ImageType }{TIFF})
@@ -135,6 +135,9 @@ func TestIsTypeSupportedSave(t *testing.T) {
 	}
 	if VipsVersion >= "8.9.0" {
 		types = append(types, struct{ name ImageType }{AVIF})
+	}
+	if VipsVersion >= "8.12.0" {
+		types = append(types, struct{ name ImageType }{GIF})
 	}
 
 	for _, n := range types {
@@ -152,11 +155,11 @@ func TestIsTypeNameSupportedSave(t *testing.T) {
 		{"jpeg", true},
 		{"png", true},
 		{"webp", true},
-		{"gif", false},
 		{"pdf", false},
 		{"tiff", VipsVersion >= "8.5.0"},
 		{"heif", VipsVersion >= "8.8.0"},
 		{"avif", VipsVersion >= "8.9.0"},
+		{"gif", VipsVersion >= "8.12.0"},
 	}
 
 	for _, n := range types {

--- a/vips.go
+++ b/vips.go
@@ -230,6 +230,9 @@ func VipsIsTypeSupportedSave(t ImageType) bool {
 	if t == AVIF {
 		return int(C.vips_type_find_save_bridge(C.HEIF)) != 0
 	}
+	if t == GIF {
+		return int(C.vips_type_find_save_bridge(C.GIF)) != 0
+	}
 	return false
 }
 
@@ -524,6 +527,8 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 		saveErr = C.vips_heifsave_bridge(tmpImage, &ptr, &length, strip, quality, lossless)
 	case AVIF:
 		saveErr = C.vips_avifsave_bridge(tmpImage, &ptr, &length, strip, quality, lossless, speed)
+	case GIF:
+		saveErr = C.vips_gifsave_bridge(tmpImage, &ptr, &length, strip)
 	default:
 		saveErr = C.vips_jpegsave_bridge(tmpImage, &ptr, &length, strip, quality, interlace)
 	}

--- a/vips.h
+++ b/vips.h
@@ -186,6 +186,11 @@ vips_type_find_save_bridge(int t) {
 		return vips_type_find("VipsOperation", "heifsave_buffer");
 	}
 #endif
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 12))
+	if (t == GIF) {
+		return vips_type_find("VipsOperation", "gifsave_buffer");
+	}
+#endif
 	return 0;
 }
 
@@ -400,6 +405,18 @@ vips_heifsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 		"strip", INT_TO_GBOOLEAN(strip),
 		"Q", quality,
 		"lossless", INT_TO_GBOOLEAN(lossless),
+		NULL
+	);
+#else
+	return 0;
+#endif
+}
+
+int
+vips_gifsave_bridge(VipsImage *in, void **buf, size_t *len, int strip) {
+#if (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 12))
+	return vips_gifsave_buffer(in, buf, len, 
+		"strip", INT_TO_GBOOLEAN(strip),
 		NULL
 	);
 #else


### PR DESCRIPTION
This PR adds the support to save GIF images via the `vips_gifsave_buffer` function added in libvips 8.12