### PR TITLE
allow effort param for png encoding when palette is true

### DIFF
--- a/options.go
+++ b/options.go
@@ -226,7 +226,9 @@ type Options struct {
 	OutputICC      string
 	InputICC       string
 	Palette        bool
-	// Speed defines the AVIF encoders CPU effort. Valid values are 0-8.
+	// Speed defines the AVIF encoders CPU effort. Valid values are: 
+	// 0-8 for AVIF encoding.
+	// 0-9 for PNG encoding.
 	Speed int
 
 	// private fields

--- a/resizer.go
+++ b/resizer.go
@@ -171,6 +171,9 @@ func applyDefaults(o Options, imageType ImageType) Options {
 	if o.Interpretation == 0 {
 		o.Interpretation = InterpretationSRGB
 	}
+	if o.Palette {
+		o.Speed = 3
+	}
 	return o
 }
 

--- a/resizer.go
+++ b/resizer.go
@@ -172,6 +172,7 @@ func applyDefaults(o Options, imageType ImageType) Options {
 		o.Interpretation = InterpretationSRGB
 	}
 	if o.Palette {
+		// Default value of effort in libvips is 7.
 		o.Speed = 3
 	}
 	return o

--- a/vips.go
+++ b/vips.go
@@ -517,7 +517,7 @@ func vipsSave(image *C.VipsImage, o vipsSaveOptions) ([]byte, error) {
 	case WEBP:
 		saveErr = C.vips_webpsave_bridge(tmpImage, &ptr, &length, strip, quality, lossless)
 	case PNG:
-		saveErr = C.vips_pngsave_bridge(tmpImage, &ptr, &length, strip, C.int(o.Compression), quality, interlace, palette)
+		saveErr = C.vips_pngsave_bridge(tmpImage, &ptr, &length, strip, C.int(o.Compression), quality, interlace, palette, speed)
 	case TIFF:
 		saveErr = C.vips_tiffsave_bridge(tmpImage, &ptr, &length)
 	case HEIF:

--- a/vips.h
+++ b/vips.h
@@ -330,14 +330,17 @@ vips_jpegsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 }
 
 int
-vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compression, int quality, int interlace, int palette) {
+vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compression, int quality, int interlace, int palette, int speed) {
 #if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 7)
+	int effort = 10 - speed;
 	return vips_pngsave_buffer(in, buf, len,
 		"strip", INT_TO_GBOOLEAN(strip),
 		"compression", compression,
 		"interlace", INT_TO_GBOOLEAN(interlace),
 		"filter", VIPS_FOREIGN_PNG_FILTER_ALL,
 		"palette", INT_TO_GBOOLEAN(palette),
+		"Q", quality,
+		"effort", effort,
 		NULL
 	);
 #else


### PR DESCRIPTION
@h2non FYI - the value of effort param in libvips for png_buffer is 1-10. 