### PR TITLE
Support PNG output on older libvips versions

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -336,7 +336,7 @@ vips_jpegsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int qual
 
 int
 vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compression, int quality, int interlace, int palette, int speed) {
-#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 7)
+#if (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 12)
 	int effort = 10 - speed;
 	return vips_pngsave_buffer(in, buf, len,
 		"strip", INT_TO_GBOOLEAN(strip),
@@ -346,6 +346,15 @@ vips_pngsave_bridge(VipsImage *in, void **buf, size_t *len, int strip, int compr
 		"palette", INT_TO_GBOOLEAN(palette),
 		"Q", quality,
 		"effort", effort,
+		NULL
+	);
+#elif (VIPS_MAJOR_VERSION >= 8 && VIPS_MINOR_VERSION >= 7)
+	return vips_pngsave_buffer(in, buf, len,
+		"strip", INT_TO_GBOOLEAN(strip),
+		"compression", compression,
+		"interlace", INT_TO_GBOOLEAN(interlace),
+		"filter", VIPS_FOREIGN_PNG_FILTER_ALL,
+		"palette", INT_TO_GBOOLEAN(palette),
 		NULL
 	);
 #else


### PR DESCRIPTION
A recent commit added new params to `vips_pngsave_bridge` (#398). However, as far as I can tell, the `effort` param is only available starting on libvips 8.12, effectively breaking PNG output for anyone stuck on older versions of the library.

This PR restores the ability of saving PNG files for users on older libvips versions, while still preserving the new features when libvips 8.12+ is available.

Fixes #401