### PR TITLE
Expose resampling kernel param in vips_reduce

### DIFF
--- a/options.go
+++ b/options.go
@@ -63,6 +63,31 @@ const (
 	Nearest
 )
 
+// resampling kernels
+type Kernel int
+
+const (
+	//The nearest pixel to the point.
+	NearestKernel Kernel = iota
+
+	//Convolve with a triangle filter.
+	LinearKernel
+
+	//Convolve with a cubic filter.
+	CubicKernel
+
+	//Convolve with a Mitchell kernel.
+	MitchellKernel
+
+	//Convolve with a two-lobe Lanczos kernel.
+	Lanczos2Kernel
+
+	//Convolve with a three-lobe Lanczos kernel.
+	Lanczos3Kernel
+
+	LastKernel
+)
+
 var interpolations = map[Interpolator]string{
 	Bicubic:  "bicubic",
 	Bilinear: "bilinear",
@@ -236,6 +261,7 @@ type Options struct {
 	WatermarkImage WatermarkImage
 	Type           ImageType
 	Interpolator   Interpolator
+	Kernel         Kernel
 	Interpretation Interpretation
 	GaussianBlur   GaussianBlur
 	Sharpen        Sharpen

--- a/resizer.go
+++ b/resizer.go
@@ -243,7 +243,7 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 
 	if o.Force || residual != 0 {
 		if residualx < 1 && residualy < 1 {
-			image, err = vipsReduce(image, 1/residualx, 1/residualy)
+			image, err = vipsReduce(image, 1/residualx, 1/residualy, o.Kernel)
 		} else {
 			image, err = vipsAffine(image, residualx, residualy, o.Interpolator, o.Extend)
 		}

--- a/vips.go
+++ b/vips.go
@@ -655,11 +655,11 @@ func vipsShrink(input *C.VipsImage, shrink int) (*C.VipsImage, error) {
 	return image, nil
 }
 
-func vipsReduce(input *C.VipsImage, xshrink float64, yshrink float64) (*C.VipsImage, error) {
+func vipsReduce(input *C.VipsImage, xshrink float64, yshrink float64, kernel Kernel) (*C.VipsImage, error) {
 	var image *C.VipsImage
 	defer C.g_object_unref(C.gpointer(input))
 
-	err := C.vips_reduce_bridge(input, &image, C.double(xshrink), C.double(yshrink))
+	err := C.vips_reduce_bridge(input, &image, C.double(xshrink), C.double(yshrink), kernel)
 	if err != 0 {
 		return nil, catchVipsError()
 	}

--- a/vips.h
+++ b/vips.h
@@ -129,8 +129,8 @@ vips_shrink_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrin
 }
 
 int
-vips_reduce_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrink) {
-	return vips_reduce(in, out, xshrink, yshrink, NULL);
+vips_reduce_bridge(VipsImage *in, VipsImage **out, double xshrink, double yshrink, int kernel) {
+	return vips_reduce(in, out, xshrink, yshrink, "kernel", kernel);
 }
 
 int


### PR DESCRIPTION
Adds [Kernel](https://www.libvips.org/API/current/libvips-resample.html#VipsKernel) in bimg.Option.

Uses the kernel param in vips_reduce https://www.libvips.org/API/current/libvips-resample.html#vips-reduce

Tries to solve https://github.com/h2non/bimg/issues/428