### PR TITLE
Remove dependency on vips7compat

### DIFF
--- a/vips.go
+++ b/vips.go
@@ -160,7 +160,7 @@ func VipsVectorSetEnabled(enable bool) {
 
 // VipsDebugInfo outputs to stdout libvips collected data. Useful for debugging.
 func VipsDebugInfo() {
-	C.im__print_all()
+	C.vips_object_print_all()
 }
 
 // VipsMemory gets memory info stats from libvips (cache size, memory allocs...)

--- a/vips.h
+++ b/vips.h
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <vips/vips.h>
 #include <vips/foreign.h>
-#include <vips/vips7compat.h>
 #include <vips/vector.h>
 
 /**


### PR DESCRIPTION
When libvips 8.13 is built with the `--disable-deprecated` flag, bimg doesn't build anymore because of errors like
```
# github.com/h2non/bimg
In file included from ./vips.h:5,
                 from vendor/github.com/h2non/bimg/vips.go:5:
/thumbs/include/vips/vips7compat.h:682:1: error: unknown type name 'DOUBLEMASK'
  682 | DOUBLEMASK *im_stats( VipsImage *in );
      | ^~~~~~~~~~
/thumbs/include/vips/vips7compat.h:684:1: error: unknown type name 'DOUBLEMASK'
  684 | DOUBLEMASK *im_measure_area( VipsImage *im,
      | ^~~~~~~~~~
```
Since `im__print_all` is the only function being used from `vips7compat.h`, this shouldn't be an issue.

See https://github.com/libvips/libvips/blob/master/libvips/include/vips/vips7compat.h#L296